### PR TITLE
test: cover Toast and Portal coexistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,9 +81,9 @@
       "license": "MIT"
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.54",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.54.tgz",
-      "integrity": "sha512-a1K94auZhtx+1jtUZbbkfFm302RqtVicJhisq9a8I9EV3UphAEAXOWQ7YVHtseClVby+uJnVI1kGdjHp3YjgDw==",
+      "version": "0.0.59",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.59.tgz",
+      "integrity": "sha512-+vFr+/x00rQKJlOXPFKTi9TonrGg8ZvNNKkemhM3kKA6rcXkgsFa2+vQnSfg64eRakGaZ1nAtf9f5MFE4kQIwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -1,4 +1,5 @@
 import { state } from '@askrjs/askr';
+import { Portal } from '@askrjs/askr/foundations';
 import { Link } from '@askrjs/askr/router';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { Button } from '../../../../src/components/button';
@@ -144,6 +145,24 @@ describe('Toast - Behavior', () => {
   afterEach(() => {
     vi.useRealTimers();
     unmount(container);
+  });
+
+  it('should coexist with a default Portal without scheduling an update loop', async () => {
+    container = mount(
+      <ToastHost>
+        <Portal>
+          <div>Portaled content</div>
+        </Portal>
+        <ToastViewport />
+        <Toast open={false}>
+          <ToastTitle>Closed notification</ToastTitle>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+
+    expect(document.body.textContent).toContain('Portaled content');
+    expect(container.querySelector('[data-toast-root="true"]')).toBeNull();
   });
 
   it('should renders toast content inside the viewport in declaration order', async () => {

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -160,9 +160,10 @@ describe('Toast - Behavior', () => {
       </ToastHost>
     );
     await flushUpdates();
+    await waitForScheduler();
 
     expect(document.body.textContent).toContain('Portaled content');
-    expect(container.querySelector('[data-toast-root="true"]')).toBeNull();
+    expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
   it('should renders toast content inside the viewport in declaration order', async () => {


### PR DESCRIPTION
## Summary

- add browser regression coverage for a closed Toast mounted beside the default Portal
- verify portaled content renders without a scheduler update loop
- refresh the lockfile to exercise the reported `@askrjs/askr` 0.0.59 runtime while preserving the declared peer-compatible range

The reported minimal case is already resolved by the current published package set, so no implementation change is required.

Closes #2

## Validation

- `npm run check`