### PR TITLE
fix(button): preserve asChild link semantics

### DIFF
--- a/src/components/button/button-interactions.ts
+++ b/src/components/button/button-interactions.ts
@@ -1,0 +1,57 @@
+import { pressable } from '@askrjs/askr/foundations/interactions';
+import type { PressEvent } from './button.types';
+
+type ButtonInteractionOptions = {
+  asChild: boolean;
+  children: unknown;
+  disabled: boolean;
+  onPress?: (event: PressEvent) => void;
+};
+
+export function getButtonInteractionProps({
+  asChild,
+  children,
+  disabled,
+  onPress,
+}: ButtonInteractionOptions) {
+  const child =
+    asChild && children && typeof children === 'object'
+      ? (children as {
+          type?: unknown;
+          props?: Record<string, unknown>;
+        })
+      : null;
+  const isAnchorHost =
+    child?.type === 'a' ||
+    typeof child?.props?.href === 'string' ||
+    typeof child?.props?.to === 'string';
+
+  if (!isAnchorHost) {
+    return pressable({
+      disabled,
+      onPress,
+      isNativeButton: !asChild || child?.type === 'button',
+    });
+  }
+
+  return {
+    onClick: (event: PressEvent) => {
+      if (disabled) {
+        event.preventDefault?.();
+        event.stopPropagation?.();
+        return;
+      }
+      onPress?.(event);
+    },
+    'aria-disabled': disabled ? 'true' : undefined,
+    tabIndex: disabled ? -1 : undefined,
+    onKeyDown: disabled
+      ? (event: KeyboardEvent) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            event.stopPropagation();
+          }
+        }
+      : undefined,
+  };
+}

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,11 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
-import { pressable } from '@askrjs/askr/foundations/interactions';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
-import type {
-  ButtonNativeProps,
-  ButtonAsChildProps,
-  PressEvent,
-} from './button.types';
+import { getButtonInteractionProps } from './button-interactions';
+import type { ButtonNativeProps, ButtonAsChildProps } from './button.types';
 
 /**
  * Headless Button component
@@ -60,45 +56,12 @@ export function Button(props: ButtonNativeProps | ButtonAsChildProps) {
     ...rest
   } = props;
 
-  const child =
-    asChild && children && typeof children === 'object'
-      ? (children as {
-          type?: unknown;
-          props?: Record<string, unknown>;
-        })
-      : null;
-  const isAnchorHost =
-    child?.type === 'a' ||
-    typeof child?.props?.href === 'string' ||
-    typeof child?.props?.to === 'string';
-  const isNativeButtonHost = !asChild || child?.type === 'button';
-
-  const interactionProps = isAnchorHost
-    ? {
-        onClick: (event: PressEvent) => {
-          if (disabled) {
-            event.preventDefault?.();
-            event.stopPropagation?.();
-            return;
-          }
-          onPress?.(event);
-        },
-        'aria-disabled': disabled ? 'true' : undefined,
-        tabIndex: disabled ? -1 : undefined,
-        onKeyDown: disabled
-          ? (event: KeyboardEvent) => {
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                event.stopPropagation();
-              }
-            }
-          : undefined,
-      }
-    : pressable({
-        disabled,
-        onPress,
-        isNativeButton: isNativeButtonHost,
-      });
+  const interactionProps = getButtonInteractionProps({
+    asChild: Boolean(asChild),
+    children,
+    disabled,
+    onPress,
+  });
 
   // Prop composition: merge user props, interaction props, and ref
   const finalProps = mergeProps(rest, {

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,7 +1,11 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
-import type { ButtonNativeProps, ButtonAsChildProps } from './button.types';
+import type {
+  ButtonNativeProps,
+  ButtonAsChildProps,
+  PressEvent,
+} from './button.types';
 
 /**
  * Headless Button component
@@ -56,12 +60,45 @@ export function Button(props: ButtonNativeProps | ButtonAsChildProps) {
     ...rest
   } = props;
 
-  // Foundation delegation: ALL interaction behavior comes from pressable
-  const interactionProps = pressable({
-    disabled,
-    onPress,
-    isNativeButton: !asChild,
-  });
+  const child =
+    asChild && children && typeof children === 'object'
+      ? (children as {
+          type?: unknown;
+          props?: Record<string, unknown>;
+        })
+      : null;
+  const isAnchorHost =
+    child?.type === 'a' ||
+    typeof child?.props?.href === 'string' ||
+    typeof child?.props?.to === 'string';
+  const isNativeButtonHost = !asChild || child?.type === 'button';
+
+  const interactionProps = isAnchorHost
+    ? {
+        onClick: (event: PressEvent) => {
+          if (disabled) {
+            event.preventDefault?.();
+            event.stopPropagation?.();
+            return;
+          }
+          onPress?.(event);
+        },
+        'aria-disabled': disabled ? 'true' : undefined,
+        tabIndex: disabled ? -1 : undefined,
+        onKeyDown: disabled
+          ? (event: KeyboardEvent) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                event.stopPropagation();
+              }
+            }
+          : undefined,
+      }
+    : pressable({
+        disabled,
+        onPress,
+        isNativeButton: isNativeButtonHost,
+      });
 
   // Prop composition: merge user props, interaction props, and ref
   const finalProps = mergeProps(rest, {

--- a/tests/browser/components/button/behavior.test.tsx
+++ b/tests/browser/components/button/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
+import { Link } from '@askrjs/askr/router';
 import { Button } from '../../../../src/components/button';
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
@@ -83,10 +84,93 @@ describe('Button - Behavior', () => {
     expect(link?.getAttribute('data-from-child')).toBe('yes');
     expect(link?.getAttribute('aria-disabled')).toBe('true');
     expect(link?.getAttribute('tabindex')).toBe('-1');
+    expect(link?.getAttribute('role')).toBeNull();
+
+    const enter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    link?.dispatchEvent(enter);
+    expect(enter.defaultPrevented).toBe(true);
 
     link?.click();
 
     expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('should preserve native anchor semantics given an enabled asChild link', () => {
+    const onPress = vi.fn();
+    container = mount(
+      <Button asChild onPress={onPress}>
+        <a href="/docs">Docs</a>
+      </Button>
+    );
+    const link = container.querySelector('a')!;
+    const enter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+
+    link.dispatchEvent(enter);
+    expect(link.getAttribute('role')).toBeNull();
+    expect(link.getAttribute('tabindex')).toBeNull();
+    expect(enter.defaultPrevented).toBe(false);
+
+    link.addEventListener('click', (event) => event.preventDefault());
+    link.click();
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('should preserve native anchor semantics given an Askr Link child', () => {
+    container = mount(
+      <Button asChild>
+        <Link href="/docs">Docs</Link>
+      </Button>
+    );
+    const link = container.querySelector('a')!;
+    const enter = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+
+    link.dispatchEvent(enter);
+    expect(link.getAttribute('role')).toBeNull();
+    expect(enter.defaultPrevented).toBe(false);
+  });
+
+  it('should use native semantics given a button asChild host', () => {
+    const onPress = vi.fn();
+    container = mount(
+      <Button asChild onPress={onPress} disabled>
+        <button type="button">Save</button>
+      </Button>
+    );
+    const button = container.querySelector('button')!;
+
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(button.getAttribute('role')).toBeNull();
+    button.click();
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('should retain synthetic button semantics given a non-native asChild host', () => {
+    const onPress = vi.fn();
+    container = mount(
+      <Button asChild onPress={onPress}>
+        <span>Save</span>
+      </Button>
+    );
+    const host = container.querySelector('span')!;
+
+    expect(host.getAttribute('role')).toBe('button');
+    expect(host.getAttribute('tabindex')).toBe('0');
+    host.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
+    );
+    expect(onPress).toHaveBeenCalledTimes(1);
   });
 
   it('should replaces stateful icon children instead of accumulating them', async () => {


### PR DESCRIPTION
Closes #4.

## Summary
- classify slotted anchors and native buttons before composing interaction behavior
- preserve anchor role, tab order, and native Enter activation
- block pointer and keyboard activation for disabled links without changing their role
- retain synthetic button semantics for non-native hosts

## Validation
- `npm run fmt`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run test:publint`
- `npm run pack:check`