### PR TITLE
fix: preserve dialog subtree across input updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.14",
+      "version": "0.0.15",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.52 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/dialog/dialog-root.tsx
+++ b/src/components/dialog/dialog-root.tsx
@@ -5,6 +5,7 @@ import {
   getPersistentPortal,
   syncOverlayPosition,
 } from '../_internal/overlay';
+import { state } from '@askrjs/askr';
 import { controllableState } from '@askrjs/askr/foundations/state';
 import {
   DialogRootContext,
@@ -49,7 +50,10 @@ export function Dialog(props: DialogProps) {
     onOpenChange,
     modal = true,
   } = props;
-  const dialogId = resolveCompoundId('dialog', id, children);
+  const generatedDialogId = state(resolveCompoundId('dialog', id, children));
+  const autoDialogId = generatedDialogId();
+  const dialogId =
+    id === undefined ? autoDialogId : resolveCompoundId('dialog', id, children);
   const openState = controllableState({
     value: open,
     defaultValue: defaultOpen,

--- a/tests/browser/components/dialog/behavior.test.tsx
+++ b/tests/browser/components/dialog/behavior.test.tsx
@@ -5,8 +5,9 @@ import { Input } from '../../../../src/components/input';
 import {
   Dialog,
   DialogClose,
-  DialogPortal,
   DialogContent,
+  DialogOverlay,
+  DialogPortal,
   DialogTrigger,
 } from '../../../../src/components/dialog';
 import { flushUpdates, mount, unmount } from '../../test-utils';
@@ -26,7 +27,7 @@ describe('Dialog - Behavior', () => {
       return (
         <Dialog defaultOpen>
           <DialogPortal>
-            <div data-testid="dialog-overlay" />
+            <DialogOverlay />
             <DialogContent>
               <Input
                 aria-label="Name"
@@ -42,9 +43,7 @@ describe('Dialog - Behavior', () => {
     container = mount(<Fixture />);
     await flushUpdates();
 
-    const overlay = document.body.querySelector(
-      '[data-testid="dialog-overlay"]'
-    );
+    const overlay = document.body.querySelector('[data-slot="dialog-overlay"]');
     const dialog = document.body.querySelector('[data-slot="dialog-content"]');
     const input = document.body.querySelector(
       'input[aria-label="Name"]'
@@ -55,7 +54,7 @@ describe('Dialog - Behavior', () => {
     input.dispatchEvent(new Event('input', { bubbles: true }));
     await flushUpdates();
 
-    expect(document.body.querySelector('[data-testid="dialog-overlay"]')).toBe(
+    expect(document.body.querySelector('[data-slot="dialog-overlay"]')).toBe(
       overlay
     );
     expect(document.body.querySelector('[data-slot="dialog-content"]')).toBe(

--- a/tests/browser/components/dialog/behavior.test.tsx
+++ b/tests/browser/components/dialog/behavior.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import { Button } from '../../../../src/components/button';
+import { Input } from '../../../../src/components/input';
 import {
   Dialog,
   DialogClose,
@@ -15,6 +17,53 @@ describe('Dialog - Behavior', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     unmount(container);
+  });
+
+  it('should preserve the open portal subtree through controlled input updates', async () => {
+    function Fixture() {
+      const name = state('Ada');
+
+      return (
+        <Dialog defaultOpen>
+          <DialogPortal>
+            <div data-testid="dialog-overlay" />
+            <DialogContent>
+              <Input
+                aria-label="Name"
+                value={name()}
+                onInput={(event) => name.set(event.target.value)}
+              />
+            </DialogContent>
+          </DialogPortal>
+        </Dialog>
+      );
+    }
+
+    container = mount(<Fixture />);
+    await flushUpdates();
+
+    const overlay = document.body.querySelector(
+      '[data-testid="dialog-overlay"]'
+    );
+    const dialog = document.body.querySelector('[data-slot="dialog-content"]');
+    const input = document.body.querySelector(
+      'input[aria-label="Name"]'
+    ) as HTMLInputElement;
+    const dialogId = dialog?.id;
+
+    input.value = 'Grace';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await flushUpdates();
+
+    expect(document.body.querySelector('[data-testid="dialog-overlay"]')).toBe(
+      overlay
+    );
+    expect(document.body.querySelector('[data-slot="dialog-content"]')).toBe(
+      dialog
+    );
+    expect(document.body.querySelector('input[aria-label="Name"]')).toBe(input);
+    expect(input.value).toBe('Grace');
+    expect(dialog?.id).toBe(dialogId);
   });
 
   it('should toggles trigger expansion state when activated', async () => {


### PR DESCRIPTION
## Summary

- keep an auto-generated Dialog identity stable for the mounted component instance
- preserve explicit `id` behavior
- add a browser regression covering overlay, dialog, input, value, and generated-ID stability

## Verification

- `npm run check`

Fixes #6