### PR TITLE
fix: clean up slider drag listeners

### DIFF
--- a/src/components/slider/slider.tsx
+++ b/src/components/slider/slider.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { controllableState } from '@askrjs/askr/foundations/state';
-import { cspNonce, state } from '@askrjs/askr';
+import { cspNonce, getSignal, state } from '@askrjs/askr';
 import {
   dynamicAttributeSelector,
   removeDynamicStyleRuleWhenUnused,
@@ -33,6 +33,7 @@ type SliderEntry = {
   thumb: HTMLElement | null;
   dragMove: ((event: PointerEvent) => void) | null;
   dragEnd: ((event: PointerEvent) => void) | null;
+  cleanupSignal: AbortSignal | null;
 };
 
 const sliderEntries = new WeakMap<object, SliderEntry>();
@@ -50,6 +51,7 @@ function getSliderEntry(identity: object) {
     thumb: null,
     dragMove: null,
     dragEnd: null,
+    cleanupSignal: null,
   };
   sliderEntries.set(identity, created);
   return created;
@@ -136,19 +138,43 @@ function beginSliderDrag(identity: object, sliderId: string) {
     );
   };
   entry.dragEnd = () => {
-    if (entry.dragMove) {
-      window.removeEventListener('pointermove', entry.dragMove);
-    }
-
-    if (entry.dragEnd) {
-      window.removeEventListener('pointerup', entry.dragEnd);
-    }
-
-    entry.dragMove = null;
-    entry.dragEnd = null;
+    endSliderDrag(identity);
   };
   window.addEventListener('pointermove', entry.dragMove);
   window.addEventListener('pointerup', entry.dragEnd);
+}
+
+function endSliderDrag(identity: object) {
+  const entry = sliderEntries.get(identity);
+  if (!entry) {
+    return;
+  }
+  if (entry.dragMove) {
+    window.removeEventListener('pointermove', entry.dragMove);
+  }
+  if (entry.dragEnd) {
+    window.removeEventListener('pointerup', entry.dragEnd);
+  }
+  entry.dragMove = null;
+  entry.dragEnd = null;
+}
+
+function registerSliderCleanup(identity: object) {
+  const entry = getSliderEntry(identity);
+  const signal = getSignal();
+  if (entry.cleanupSignal === signal) {
+    return;
+  }
+  entry.cleanupSignal = signal;
+  signal.addEventListener(
+    'abort',
+    () => {
+      endSliderDrag(identity);
+      sliderEntries.delete(identity);
+      sliderContexts.delete(identity);
+    },
+    { once: true }
+  );
 }
 
 function resolveLiveSliderRoot(identity: object, sliderId: string) {
@@ -173,6 +199,7 @@ export function Slider(props: SliderProps) {
   const { max, min, step } = normalizeSliderConfig(props);
   const sliderId = resolveCompoundId('slider', id, children);
   const identity = state<object>({})();
+  registerSliderCleanup(identity);
   const valueState = controllableState({
     value,
     defaultValue: snapRangeValue(defaultValue ?? min, min, max, step),

--- a/tests/browser/components/slider/behavior.test.tsx
+++ b/tests/browser/components/slider/behavior.test.tsx
@@ -85,48 +85,51 @@ describe('Slider - Behavior', () => {
 
   it('should remove active drag listeners when unmounted mid-drag', () => {
     const removeEventListener = vi.spyOn(window, 'removeEventListener');
-    container = mount(
-      <Slider defaultValue={20}>
-        <SliderTrack>
-          <SliderRange />
-          <SliderThumb />
-        </SliderTrack>
-      </Slider>
-    );
-    const track = container.querySelector(
-      '[data-slider-track="true"]'
-    ) as HTMLDivElement;
-    track.getBoundingClientRect = () =>
-      ({
-        left: 0,
-        top: 0,
-        width: 100,
-        height: 10,
-        right: 100,
-        bottom: 10,
-        x: 0,
-        y: 0,
-        toJSON: () => null,
-      }) as DOMRect;
-    track.dispatchEvent(
-      new PointerEvent('pointerdown', {
-        bubbles: true,
-        clientX: 50,
-        clientY: 5,
-      })
-    );
+    try {
+      container = mount(
+        <Slider defaultValue={20}>
+          <SliderTrack>
+            <SliderRange />
+            <SliderThumb />
+          </SliderTrack>
+        </Slider>
+      );
+      const track = container.querySelector(
+        '[data-slider-track="true"]'
+      ) as HTMLDivElement;
+      track.getBoundingClientRect = () =>
+        ({
+          left: 0,
+          top: 0,
+          width: 100,
+          height: 10,
+          right: 100,
+          bottom: 10,
+          x: 0,
+          y: 0,
+          toJSON: () => null,
+        }) as DOMRect;
+      track.dispatchEvent(
+        new PointerEvent('pointerdown', {
+          bubbles: true,
+          clientX: 50,
+          clientY: 5,
+        })
+      );
 
-    unmount(container);
+      unmount(container);
 
-    expect(removeEventListener).toHaveBeenCalledWith(
-      'pointermove',
-      expect.any(Function)
-    );
-    expect(removeEventListener).toHaveBeenCalledWith(
-      'pointerup',
-      expect.any(Function)
-    );
-    removeEventListener.mockRestore();
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'pointermove',
+        expect.any(Function)
+      );
+      expect(removeEventListener).toHaveBeenCalledWith(
+        'pointerup',
+        expect.any(Function)
+      );
+    } finally {
+      removeEventListener.mockRestore();
+    }
   });
 
   it('should support Home/End/PageUp/PageDown keyboard boundaries', async () => {

--- a/tests/browser/components/slider/behavior.test.tsx
+++ b/tests/browser/components/slider/behavior.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   Slider,
   SliderRange,
@@ -81,6 +81,52 @@ describe('Slider - Behavior', () => {
     expect(
       getComputedStyle(root).getPropertyValue('--ak-slider-percentage').trim()
     ).toBe('25%');
+  });
+
+  it('should remove active drag listeners when unmounted mid-drag', () => {
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    container = mount(
+      <Slider defaultValue={20}>
+        <SliderTrack>
+          <SliderRange />
+          <SliderThumb />
+        </SliderTrack>
+      </Slider>
+    );
+    const track = container.querySelector(
+      '[data-slider-track="true"]'
+    ) as HTMLDivElement;
+    track.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 10,
+        right: 100,
+        bottom: 10,
+        x: 0,
+        y: 0,
+        toJSON: () => null,
+      }) as DOMRect;
+    track.dispatchEvent(
+      new PointerEvent('pointerdown', {
+        bubbles: true,
+        clientX: 50,
+        clientY: 5,
+      })
+    );
+
+    unmount(container);
+
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'pointermove',
+      expect.any(Function)
+    );
+    expect(removeEventListener).toHaveBeenCalledWith(
+      'pointerup',
+      expect.any(Function)
+    );
+    removeEventListener.mockRestore();
   });
 
   it('should support Home/End/PageUp/PageDown keyboard boundaries', async () => {


### PR DESCRIPTION
Closes #9.

Registers per-instance cleanup with the component abort signal, removes active window drag listeners on unmount, and deletes the corresponding weak-map entries. Pointerup continues through the same idempotent cleanup path.

The browser regression starts a drag, unmounts before pointerup, and proves both global listeners are removed. Full local npm run check passes, including all unit/check/jsdom/browser, type, build, publint, and package gates.