### PR TITLE
fix(security): release DismissableLayer registry entries

### DIFF
--- a/src/components/dismissable-layer/dismissable-layer.tsx
+++ b/src/components/dismissable-layer/dismissable-layer.tsx
@@ -1,5 +1,6 @@
 import { Slot, createLayer } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
+import { getSignal } from '@askrjs/askr';
 import { resolveCompoundId } from '../_internal/id';
 import type {
   DismissableLayerAsChildProps,
@@ -22,6 +23,7 @@ type LayerEntry = {
   onPointerDownOutside?: (event: PointerEvent) => void;
   onInteractOutside?: (event: Event) => void;
   onDismiss?: () => void;
+  cleanupSignal: AbortSignal | null;
 };
 
 const layerManager = createLayer();
@@ -118,10 +120,34 @@ function getLayerEntry(layerId: string): LayerEntry {
     unregisterDocumentListeners: null,
     disabled: false,
     disableOutsidePointerEvents: false,
+    cleanupSignal: null,
   };
 
   layerEntries.set(layerId, created);
   return created;
+}
+
+function registerLayerCleanup(layerId: string, entry: LayerEntry) {
+  const signal = getSignal();
+  if (entry.cleanupSignal === signal) {
+    return;
+  }
+  entry.cleanupSignal = signal;
+  signal.addEventListener(
+    'abort',
+    () => {
+      if (entry.cleanupSignal !== signal) {
+        return;
+      }
+      unregisterLayer(layerId);
+      layerEntries.delete(layerId);
+    },
+    { once: true }
+  );
+}
+
+export function dismissableLayerEntryCountForTests(): number {
+  return layerEntries.size;
 }
 
 function unregisterLayer(layerId: string) {
@@ -209,6 +235,7 @@ export function DismissableLayer(
 
   const layerId = resolveCompoundId('dismissable-layer', id, children);
   const entry = getLayerEntry(layerId);
+  registerLayerCleanup(layerId, entry);
   entry.disabled = disabled;
   entry.disableOutsidePointerEvents = disableOutsidePointerEvents;
   entry.onEscapeKeyDown = onEscapeKeyDown;

--- a/tests/browser/components/dismissable-layer/behavior.test.tsx
+++ b/tests/browser/components/dismissable-layer/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { DismissableLayer } from '../../../../src/components/dismissable-layer';
+import { dismissableLayerEntryCountForTests } from '../../../../src/components/dismissable-layer/dismissable-layer';
 import { mount, unmount } from '../../test-utils';
 
 describe('DismissableLayer - Behavior', () => {
@@ -121,5 +122,19 @@ describe('DismissableLayer - Behavior', () => {
     );
 
     expect(onDismiss).toHaveBeenCalledTimes(0);
+  });
+
+  it('should delete per-ID registry entries after unmount', () => {
+    const baseline = dismissableLayerEntryCountForTests();
+    for (let index = 0; index < 25; index += 1) {
+      container = mount(
+        <DismissableLayer id={`transient-${index}`}>
+          <div>Layer</div>
+        </DismissableLayer>
+      );
+      unmount(container);
+    }
+
+    expect(dismissableLayerEntryCountForTests()).toBe(baseline);
   });
 });


### PR DESCRIPTION
Closes #11

Deletes per-ID registry state on component cleanup while preventing stale cleanup callbacks from deleting a replacement entry.

Verification:
- focused DismissableLayer and Menubar browser tests: 10 passed
- npm run check: passed (334 browser tests)