### PR TITLE
chore: release v0.0.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.17",
+      "version": "0.0.18",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.64 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",


### PR DESCRIPTION
## Summary

- bump `@askrjs/ui` from `0.0.17` to `0.0.18`
- synchronize the root package-lock version fields
- publish the merged DismissableLayer registry cleanup and Slider listener cleanup

## Validation

- `npm ci`
- `npx playwright install chromium`
- `npm run fmt -- --check`
- `npm run check`
- packed-artifact ESM consumer smoke for root, `@askrjs/ui/slider`, and `@askrjs/ui/dismissable-layer` against `@askrjs/askr@0.0.70`

## Module contract note

The repository release contract currently validates ESM and types. `docs/regression-coverage.md` explicitly excludes CJS runtime loading because `@askrjs/askr` is ESM-only; this release does not change that pre-existing limitation.