### PR TITLE
fix: support dynamic ToggleGroup items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.18",
+      "version": "0.0.19",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@askrjs/askr": ">=0.0.64 <0.1.0",
+        "@askrjs/askr": ">=0.0.75 <0.1.0",
         "@askrjs/vite": ">=0.0.5 <0.1.0",
         "@types/node": "^26.1.1",
         "@vitest/browser-playwright": "4.1.10",
@@ -26,7 +26,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@askrjs/askr": ">=0.0.64 <0.1.0"
+        "@askrjs/askr": ">=0.0.75 <0.1.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -81,9 +81,9 @@
       "license": "MIT"
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.64.tgz",
-      "integrity": "sha512-L5uCEbtfKHj0VSa/TI2+nPWpYuOUf0ttMOvSgTiNu8DLXpP4Xd3sFniNJ0a67EfTfIOu4H7hFXzi3PzroK7Y1A==",
+      "version": "0.0.75",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.75.tgz",
+      "integrity": "sha512-jpT4yb+awkCk2ESyOppoGMZ/pTLvMnaM4t30ZUfRDMfks36ERCOm4y2rfxkjD1rtvt/tsFvGJcwbOL7j/JWDrg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",
@@ -236,7 +236,7 @@
     "test:checks": "vp test run -c vitest.test.checks.config.ts"
   },
   "devDependencies": {
-    "@askrjs/askr": ">=0.0.64 <0.1.0",
+    "@askrjs/askr": ">=0.0.75 <0.1.0",
     "@askrjs/vite": ">=0.0.5 <0.1.0",
     "@types/node": "^26.1.1",
     "@vitest/browser-playwright": "4.1.10",
@@ -250,7 +250,7 @@
     "vite-plus": "^0.2.4"
   },
   "peerDependencies": {
-    "@askrjs/askr": ">=0.0.64 <0.1.0"
+    "@askrjs/askr": ">=0.0.75 <0.1.0"
   },
   "engines": {
     "node": ">=18"

--- a/src/components/_internal/types.ts
+++ b/src/components/_internal/types.ts
@@ -29,7 +29,7 @@ export type ButtonLikeProps<
 export type ButtonLikeAsChildProps = ButtonLikeOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
   type?: never;
 };
 
@@ -49,5 +49,5 @@ export type BoxProps<TTag extends keyof JSX.IntrinsicElements, TElement> = Omit<
 export type BoxAsChildProps = BoxOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -47,6 +47,9 @@ export function Accordion(props: AccordionProps) {
     orientation = 'vertical',
     ref,
     type = 'single',
+    value: _value,
+    defaultValue: _defaultValue,
+    onValueChange: _onValueChange,
     ...rest
   } = props;
   const accordionId = resolveCompoundId('accordion', id, children);
@@ -59,6 +62,7 @@ export function Accordion(props: AccordionProps) {
       ? ((props as AccordionMultipleProps).defaultValue ?? [])
       : ((props as AccordionSingleProps).defaultValue ?? '')
   );
+  internalValueState();
   const valueState = (() => {
     const read = () => {
       if (type === 'multiple') {

--- a/src/components/button/button.types.ts
+++ b/src/components/button/button.types.ts
@@ -67,7 +67,7 @@ export type ButtonNativeProps = Omit<
 export type ButtonAsChildProps = ButtonOwnProps & {
   asChild: true;
   children: ButtonAsChildElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
   type?: never;
 };
 

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,6 +1,6 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { controllableState } from '@askrjs/askr/foundations/state';
-import { mergeProps } from '@askrjs/askr/foundations/utilities';
+import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import type {
   CheckboxInputProps,
@@ -116,7 +116,11 @@ export function Checkbox(props: CheckboxInputProps | CheckboxAsChildProps) {
   }
 
   const finalProps = mergeProps(rest, {
-    ref,
+    ref: composeRefs(ref, (node: HTMLInputElement | null) => {
+      if (node) {
+        node.indeterminate = indeterminate;
+      }
+    }),
     onClick: (e: Event) => {
       toggleChecked(e as PressEvent);
 
@@ -140,7 +144,6 @@ export function Checkbox(props: CheckboxInputProps | CheckboxAsChildProps) {
     <input
       type="checkbox"
       checked={currentChecked}
-      indeterminate={indeterminate}
       disabled={disabled}
       required={required}
       name={name}

--- a/src/components/checkbox/checkbox.types.ts
+++ b/src/components/checkbox/checkbox.types.ts
@@ -68,7 +68,7 @@ export type CheckboxInputProps = Omit<
 export type CheckboxAsChildProps = CheckboxOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };
 
 /**

--- a/src/components/collapsible/collapsible.types.ts
+++ b/src/components/collapsible/collapsible.types.ts
@@ -49,7 +49,7 @@ export interface CollapsibleTriggerAsChildProps {
   /** Child content */
   children: JSXElement;
   /** Ref forwarding */
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 }
 
 /**
@@ -77,5 +77,5 @@ export interface CollapsibleContentAsChildProps {
   /** Force mount even when closed (for animation) */
   forceMount?: boolean;
   /** Ref forwarding */
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 }

--- a/src/components/dismissable-layer/dismissable-layer.types.ts
+++ b/src/components/dismissable-layer/dismissable-layer.types.ts
@@ -24,5 +24,5 @@ export type DismissableLayerProps = Omit<
 export type DismissableLayerAsChildProps = DismissableLayerOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };

--- a/src/components/focus-scope/focus-scope.types.ts
+++ b/src/components/focus-scope/focus-scope.types.ts
@@ -22,5 +22,5 @@ export type FocusScopeProps = Omit<
 export type FocusScopeAsChildProps = FocusScopeOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };

--- a/src/components/input/input.types.ts
+++ b/src/components/input/input.types.ts
@@ -24,7 +24,7 @@ export type InputInputProps = Omit<
 export type InputAsChildProps = InputOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };
 
 export type DebouncedInputProps = Omit<InputInputProps, 'onInput' | 'type'> & {

--- a/src/components/label/label.types.ts
+++ b/src/components/label/label.types.ts
@@ -16,7 +16,7 @@ export type LabelLabelProps = Omit<Props, 'children'> &
 export type LabelAsChildProps = LabelOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };
 
 export type LabelProps = LabelLabelProps | LabelAsChildProps;

--- a/src/components/radio-group/radio-group.types.ts
+++ b/src/components/radio-group/radio-group.types.ts
@@ -39,5 +39,5 @@ export type RadioGroupItemProps = Omit<
 export type RadioGroupItemAsChildProps = RadioGroupItemOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };

--- a/src/components/switch/switch.types.ts
+++ b/src/components/switch/switch.types.ts
@@ -25,7 +25,7 @@ export type SwitchButtonProps = Omit<
 export type SwitchAsChildProps = SwitchOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
   type?: never;
 };
 

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -17,7 +17,7 @@ type TableNativeProps<
 type TableAsChildBaseProps = TableBaseProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };
 
 export type TableProps =

--- a/src/components/textarea/textarea.types.ts
+++ b/src/components/textarea/textarea.types.ts
@@ -19,7 +19,7 @@ export type TextareaElementProps = Omit<
 export type TextareaAsChildProps = TextareaOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };
 
 export type TextareaProps = TextareaElementProps | TextareaAsChildProps;

--- a/src/components/toggle-group/toggle-group-root.tsx
+++ b/src/components/toggle-group/toggle-group-root.tsx
@@ -32,6 +32,9 @@ export function ToggleGroup(props: ToggleGroupProps) {
     orientation = 'horizontal',
     ref,
     type = 'single',
+    value: _value,
+    defaultValue: _defaultValue,
+    onValueChange: _onValueChange,
     ...rest
   } = props;
   const groupId = resolveCompoundId(

--- a/src/components/toggle/toggle.types.ts
+++ b/src/components/toggle/toggle.types.ts
@@ -54,7 +54,7 @@ export type ToggleButtonProps = Omit<
 export type ToggleAsChildProps = ToggleOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
   type?: never;
 };
 

--- a/src/components/virtual-table/virtual-table.tsx
+++ b/src/components/virtual-table/virtual-table.tsx
@@ -936,10 +936,18 @@ export function VirtualTable<Row>(
       'aria-describedby': ariaDescribedBy,
       'aria-rowcount': String(stateSnapshot.count),
       'aria-colcount': String(columns.length),
-      tabIndex: tabIndex ?? 0,
-      ...(onKeyDown ? { onKeyDown } : {}),
-      ...(onFocus ? { onFocus } : {}),
-      ...(onBlur ? { onBlur } : {}),
+      tabIndex: (tabIndex ?? 0) as JSX.IntrinsicElements['table']['tabIndex'],
+      ...(onKeyDown
+        ? {
+            onKeyDown: onKeyDown as JSX.IntrinsicElements['table']['onKeyDown'],
+          }
+        : {}),
+      ...(onFocus
+        ? { onFocus: onFocus as JSX.IntrinsicElements['table']['onFocus'] }
+        : {}),
+      ...(onBlur
+        ? { onBlur: onBlur as JSX.IntrinsicElements['table']['onBlur'] }
+        : {}),
     },
     {
       ref: entry.tableRef,

--- a/src/components/visually-hidden/visually-hidden.types.ts
+++ b/src/components/visually-hidden/visually-hidden.types.ts
@@ -17,7 +17,7 @@ export type VisuallyHiddenSpanProps = Omit<
 export type VisuallyHiddenAsChildProps = VisuallyHiddenOwnProps & {
   asChild: true;
   children: JSXElement;
-  ref?: Ref<unknown>;
+  ref?: Ref<Element>;
 };
 
 export type VisuallyHiddenProps =

--- a/tests/browser/components/accordion/behavior.test.tsx
+++ b/tests/browser/components/accordion/behavior.test.tsx
@@ -118,4 +118,60 @@ describe('Accordion - Behavior', () => {
     ).filter((element) => element.textContent?.includes('multiple'));
     expect(multiOpen).toHaveLength(2);
   });
+
+  it('should preserve consecutive uncontrolled updates before rerender', async () => {
+    const changes: string[][] = [];
+
+    container = mount(
+      <Accordion
+        type="multiple"
+        onValueChange={(value) => changes.push([...value])}
+      >
+        <AccordionItem value="one">
+          <AccordionHeader>
+            <AccordionTrigger>One</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionContent>First</AccordionContent>
+        </AccordionItem>
+        <AccordionItem value="two">
+          <AccordionHeader>
+            <AccordionTrigger>Two</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionContent>Second</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    getButtonByText(container, 'One').click();
+    getButtonByText(container, 'Two').click();
+
+    expect(changes).toEqual([['one'], ['one', 'two']]);
+
+    await flushUpdates();
+
+    expect(
+      container.querySelectorAll(
+        `[${ACCORDION_A11Y_CONTRACT.EXPANDED_ATTRIBUTE}="true"]`
+      )
+    ).toHaveLength(2);
+  });
+
+  it('should keep controlled state props off the native root', () => {
+    container = mount(
+      <Accordion value="one" onValueChange={() => undefined}>
+        <AccordionItem value="one">
+          <AccordionHeader>
+            <AccordionTrigger>One</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionContent>First</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+
+    const root = container.querySelector('[data-slot="accordion"]');
+
+    expect(root?.getAttribute('value')).toBeNull();
+    expect(root?.getAttribute('defaultvalue')).toBeNull();
+    expect(root?.getAttribute('onvaluechange')).toBeNull();
+  });
 });

--- a/tests/browser/components/checkbox/behavior.test.tsx
+++ b/tests/browser/components/checkbox/behavior.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import { Checkbox } from '../../../../src/components/checkbox/checkbox';
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
@@ -85,6 +86,43 @@ describe('Checkbox - Behavior', () => {
     expect(input).toBeTruthy();
     expect(input?.getAttribute('aria-checked')).toBeNull();
     expect(input?.getAttribute('data-state')).toBe('indeterminate');
+    expect(input?.indeterminate).toBe(true);
+  });
+
+  it('should update native indeterminate state on a retained input', async () => {
+    let setIndeterminate = (_value: boolean) => undefined;
+    let refNode: HTMLInputElement | null = null;
+    const App = () => {
+      const indeterminate = state(false);
+      setIndeterminate = indeterminate.set;
+
+      return (
+        <Checkbox
+          indeterminate={indeterminate()}
+          ref={(node) => (refNode = node)}
+        />
+      );
+    };
+
+    container = mount(<App />);
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    expect(refNode).toBe(input);
+    expect(input.indeterminate).toBe(false);
+
+    setIndeterminate(true);
+    await flushUpdates();
+
+    expect(container.querySelector('input')).toBe(input);
+    expect(refNode).toBe(input);
+    expect(input.indeterminate).toBe(true);
+
+    setIndeterminate(false);
+    await flushUpdates();
+
+    expect(container.querySelector('input')).toBe(input);
+    expect(refNode).toBe(input);
+    expect(input.indeterminate).toBe(false);
   });
 
   it('should forwards refs to the asChild host', () => {

--- a/tests/browser/components/toggle-group/behavior.test.tsx
+++ b/tests/browser/components/toggle-group/behavior.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { For } from '@askrjs/askr';
 import {
   ToggleGroup,
   ToggleGroupItem,
@@ -146,6 +147,84 @@ describe('ToggleGroup - Behavior', () => {
     expect(
       getToggleByText(container, 'Right').getAttribute('aria-pressed')
     ).toBe('true');
+  });
+
+  it('should support toggle items produced by a computed array', async () => {
+    const items = [
+      { value: 'all', label: 'All' },
+      { value: 'midge', label: 'Midge' },
+    ];
+    function ComputedToggleGroup() {
+      return (
+        <ToggleGroup defaultValue="all">
+          {items.map((item) => (
+            <ToggleGroupItem key={item.value} value={item.value}>
+              {item.label}
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      );
+    }
+
+    container = mount(<ComputedToggleGroup />);
+
+    expect(getToggleByText(container, 'All').getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+
+    getToggleByText(container, 'Midge').click();
+    await flushUpdates();
+
+    expect(
+      getToggleByText(container, 'Midge').getAttribute('aria-pressed')
+    ).toBe('true');
+  });
+
+  it('should support toggle items produced by For', async () => {
+    const items = [
+      { value: 'all', label: 'All' },
+      { value: 'midge', label: 'Midge' },
+    ];
+    function ForToggleGroup() {
+      return (
+        <ToggleGroup defaultValue="all">
+          <For each={items} by={(item) => item.value}>
+            {(item) => (
+              <ToggleGroupItem value={item.value}>{item.label}</ToggleGroupItem>
+            )}
+          </For>
+        </ToggleGroup>
+      );
+    }
+
+    container = mount(<ForToggleGroup />);
+
+    expect(getToggleByText(container, 'All').getAttribute('aria-pressed')).toBe(
+      'true'
+    );
+
+    getToggleByText(container, 'Midge').click();
+    await flushUpdates();
+
+    expect(
+      getToggleByText(container, 'Midge').getAttribute('aria-pressed')
+    ).toBe('true');
+  });
+
+  it('should reject computed toggle items outside ToggleGroup', () => {
+    const items = [{ value: 'all', label: 'All' }];
+
+    expect(() => {
+      container = mount(
+        <>
+          {items.map((item) => (
+            <ToggleGroupItem key={item.value} value={item.value}>
+              {item.label}
+            </ToggleGroupItem>
+          ))}
+        </>
+      );
+    }).toThrow('ToggleGroup components must be used within <ToggleGroup>');
   });
 
   it('should emits normalized values for single and multiple groups', async () => {
@@ -301,6 +380,9 @@ describe('ToggleGroup - Behavior', () => {
         <ToggleGroupItem value="right">Right</ToggleGroupItem>
       </ToggleGroup>
     );
+    const group = container.querySelector('[data-slot="toggle-group"]');
+
+    expect(group?.getAttribute('value')).toBeNull();
     getToggleByText(container, 'Right').click();
     await flushUpdates();
 


### PR DESCRIPTION
## Summary

- validate ToggleGroup items produced by both computed arrays and Askr For boundaries
- require the context-propagation fix published in @askrjs/askr 0.0.75
- keep controlled ToggleGroup and Accordion state props off their DOM hosts
- align asChild ref types and VirtualTable handlers with the current Askr contracts
- set native checkbox indeterminate state through a composed retained-node ref
- bump @askrjs/ui to 0.0.19

## Validation

- clean npm ci from the registry lock installs @askrjs/askr 0.0.75
- npm run check
  - 12 jsdom tests
  - 340 browser tests
  - build, lint, typecheck, publint, and package dry-run

## Regression coverage

- computed ToggleGroupItem arrays mount and update selection
- ToggleGroupItem values produced by For mount and update selection
- ToggleGroupItem outside a group still fails closed
- controlled state props do not leak to DOM hosts
- a retained checkbox input updates and clears native indeterminate state while preserving its external ref

Closes #14