### PR TITLE
fix: support dynamic group descendants

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -59,6 +59,29 @@ These are documentation groupings only.
 - `VirtualTable` is a fixed-height table windowing primitive with a sticky
   head, stable keys, selection, and keyboard navigation.
 
+## Dynamic descendants
+
+Dynamic descendants are a supported composition contract for
+context-coordinated group families. Their parts may be written directly,
+nested in caller markup, returned from an array `.map()`, or rendered with
+Askr's `<For>`.
+
+| Family         | Dynamic descendant contract                                 |
+| -------------- | ----------------------------------------------------------- |
+| `accordion`    | `AccordionItem` and its parts retain Accordion context.     |
+| `dropdown`     | `DropdownItem` retains Dropdown and content context.        |
+| `menu`         | `MenuItem` retains Menu and content context.                |
+| `menubar`      | Menus, content, submenus, and items retain Menubar context. |
+| `radio-group`  | `RadioGroupItem` retains RadioGroup context.                |
+| `select`       | Select groups, labels, and items retain Select context.     |
+| `slider`       | Track, range, and thumb parts retain Slider context.        |
+| `toggle-group` | `ToggleGroupItem` retains ToggleGroup context.              |
+
+Use stable `key` props for array-mapped children and a stable `by` selector for
+`<For>`. Dynamically reordered `MenubarMenu` children should also provide a
+stable, unique `value`; it preserves each menu's trigger, content, and portal
+identity as its position changes. Duplicate sibling values are rejected.
+
 ## Virtualization
 
 ```ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.19",
+      "version": "0.0.20",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.75 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/accordion/accordion.types.ts
+++ b/src/components/accordion/accordion.types.ts
@@ -8,6 +8,7 @@ import type {
 export type AccordionOrientation = 'vertical' | 'horizontal';
 
 type AccordionSharedOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   orientation?: AccordionOrientation;

--- a/src/components/dropdown/dropdown.types.ts
+++ b/src/components/dropdown/dropdown.types.ts
@@ -8,6 +8,7 @@ import type {
 import type { OverlayAlign, OverlaySide } from '../_internal/overlay';
 
 export type DropdownOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   open?: boolean;

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -8,6 +8,7 @@ import type {
 } from '../_internal/types';
 
 export type MenuOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   orientation?: Orientation;

--- a/src/components/menubar/menubar-menu.tsx
+++ b/src/components/menubar/menubar-menu.tsx
@@ -65,13 +65,14 @@ export function MenubarMenu(props: MenubarMenuProps) {
   const renderContext = readMenubarRootRenderContext();
   const menuIndex = renderContext.claimMenuIndex();
   const menuKey = props.value ?? `menu-${menuIndex}`;
+  const portalRecord = root.ensureMenuPortal(menuKey);
   const menuContext: MenubarMenuContextValue = {
     menuKey,
     menuIndex,
-    triggerId: resolvePartId(root.menubarId, `trigger-${menuIndex}`),
-    contentId: resolvePartId(root.menubarId, `content-${menuIndex}`),
-    portalId: resolvePartId(root.menubarId, `portal-${menuIndex}`),
-    overlayIdentity: root.portalIdentities[menuIndex]!,
+    triggerId: resolvePartId(root.menubarId, `trigger-${portalRecord.ordinal}`),
+    contentId: resolvePartId(root.menubarId, `content-${portalRecord.ordinal}`),
+    portalId: resolvePartId(root.menubarId, `portal-${portalRecord.ordinal}`),
+    overlayIdentity: portalRecord.identity,
     path: [menuKey],
   };
 

--- a/src/components/menubar/menubar-root.tsx
+++ b/src/components/menubar/menubar-root.tsx
@@ -1,16 +1,14 @@
-import { cspNonce, state } from '@askrjs/askr';
+import { cspNonce, getSignal, state } from '@askrjs/askr';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { focusSelectedCollectionItem } from '../_internal/focus';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
 import { getCompositeCollection } from '../_internal/composite';
-import { collectJsxElements } from '../_internal/jsx';
 import {
   captureOverlayNonce,
   createOverlayIdentity,
   getPersistentPortal,
 } from '../_internal/overlay';
-import { MenubarMenu } from './menubar-menu';
 import {
   createMenubarRootRenderContext,
   MenubarRootContext,
@@ -18,16 +16,48 @@ import {
   resolveMenubarRootState,
   type MenubarRootStateInput,
   type MenubarRootContextValue,
+  type MenubarPortalRecord,
 } from './menubar.shared';
 import type { MenubarProps } from './menubar.types';
 
+type MenubarPortalRegistry = {
+  activeKeys: Set<string>;
+  byKey: Map<string, MenubarPortalRecord>;
+  nextOrdinal: number;
+};
+
+const menubarPortalRegistries = new WeakMap<object, MenubarPortalRegistry>();
+
+function getMenubarPortalRegistry(identity: object) {
+  const existing = menubarPortalRegistries.get(identity);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created: MenubarPortalRegistry = {
+    activeKeys: new Set(),
+    byKey: new Map(),
+    nextOrdinal: 0,
+  };
+  menubarPortalRegistries.set(identity, created);
+  return created;
+}
+
 export function Menubar(props: MenubarProps) {
   const { children, id, loop = true, ref, ...rest } = props;
-  const menubarId = resolveCompoundId('menubar', id, children);
+  const nonce = cspNonce();
+  const generatedMenubarId = state(resolveCompoundId('menubar', id, children));
+  const menubarId =
+    id === undefined
+      ? generatedMenubarId()
+      : resolveCompoundId('menubar', id, children);
   const openPathState = state<string[]>([]);
   const portalEpochState = state(0);
   const currentTriggerIndexState = state(0);
-  const portalIdentitiesState = state<object[]>([]);
+  const identity = state<object>({})();
+  const portalRegistry = getMenubarPortalRegistry(identity);
+  const renderedMenuKeys = new Set<string>();
   const setOpenPath = (path: string[]) => {
     openPathState.set(path);
   };
@@ -40,9 +70,33 @@ export function Menubar(props: MenubarProps) {
   };
   const runtimeRenderContext = createMenubarRootRenderContext();
   const rootState = resolveMenubarRootState(rootContextBase);
+  const ensureMenuPortal = (menuKey: string) => {
+    if (renderedMenuKeys.has(menuKey)) {
+      throw new Error(
+        `MenubarMenu values must be unique within <Menubar>; received duplicate value "${menuKey}"`
+      );
+    }
+
+    renderedMenuKeys.add(menuKey);
+    const existing = portalRegistry.byKey.get(menuKey);
+
+    if (existing) {
+      return existing;
+    }
+
+    const created: MenubarPortalRecord = {
+      identity: createOverlayIdentity(),
+      ordinal: portalRegistry.nextOrdinal,
+    };
+    portalRegistry.nextOrdinal += 1;
+    portalRegistry.byKey.set(menuKey, created);
+    captureOverlayNonce(created.identity, nonce);
+
+    return created;
+  };
   const rootContext: MenubarRootContextValue = {
     ...rootContextBase,
-    portalIdentities: portalIdentitiesState(),
+    ensureMenuPortal,
     openPath: openPathState(),
     getOpenPath: openPathState,
     setOpenPath,
@@ -54,15 +108,8 @@ export function Menubar(props: MenubarProps) {
     setCurrentTriggerIndex,
     resolvedState: rootState,
   };
-  const portalIds = collectJsxElements(
-    children,
-    (element) => element.type === MenubarMenu
-  ).map((_element, index) => resolvePartId(menubarId, `portal-${index}`));
-  while (rootContext.portalIdentities.length < portalIds.length) {
-    rootContext.portalIdentities.push(createOverlayIdentity());
-  }
-  for (const identity of rootContext.portalIdentities) {
-    captureOverlayNonce(identity, cspNonce());
+  for (const record of portalRegistry.byKey.values()) {
+    captureOverlayNonce(record.identity, nonce);
   }
   const collection = getCompositeCollection(menubarId);
   const nav = rovingFocus({
@@ -83,19 +130,40 @@ export function Menubar(props: MenubarProps) {
     'data-slot': 'menubar',
     'data-menubar': 'true',
   });
+  const signal = getSignal();
+  queueMicrotask(() => {
+    if (signal.aborted) {
+      return;
+    }
+
+    const activeKeys = portalRegistry.activeKeys;
+    const activeKeysChanged =
+      activeKeys.size !== renderedMenuKeys.size ||
+      Array.from(activeKeys).some((key) => !renderedMenuKeys.has(key));
+
+    if (activeKeysChanged) {
+      portalRegistry.activeKeys = renderedMenuKeys;
+      portalEpochState.set(portalEpochState() + 1);
+    }
+  });
 
   return (
     <MenubarRootContext value={rootContext}>
       <MenubarRootRenderContext value={runtimeRenderContext}>
         <div {...finalProps}>{children}</div>
         {
-          portalIds.map((portalId, index) => {
-            const PortalHost = getPersistentPortal(
-              rootContext.portalIdentities[index]!
+          Array.from(portalRegistry.activeKeys).map((menuKey) => {
+            const record = portalRegistry.byKey.get(menuKey)!;
+            const PortalHost = getPersistentPortal(record.identity);
+            const portalId = resolvePartId(
+              menubarId,
+              `portal-${record.ordinal}`
             );
 
             return (
-              <PortalHost key={`${portalId}-${rootContext.portalEpoch}`} />
+              <PortalHost
+                key={`${menuKey}-${portalId}-${rootContext.portalEpoch}`}
+              />
             );
           }) as unknown as JSX.Element
         }

--- a/src/components/menubar/menubar.shared.ts
+++ b/src/components/menubar/menubar.shared.ts
@@ -19,7 +19,7 @@ export type MenubarSurfaceMetadata = {
 
 export type MenubarRootContextValue = {
   menubarId: string;
-  portalIdentities: object[];
+  ensureMenuPortal: (menuKey: string) => MenubarPortalRecord;
   openPath: string[];
   getOpenPath: () => string[];
   setOpenPath: (path: string[]) => void;
@@ -29,6 +29,11 @@ export type MenubarRootContextValue = {
   currentTriggerIndexCandidate: number;
   setCurrentTriggerIndex: (index: number) => void;
   resolvedState: MenubarRootResolvedState;
+};
+
+export type MenubarPortalRecord = {
+  identity: object;
+  ordinal: number;
 };
 
 export type MenubarRootStateInput = {

--- a/src/components/menubar/menubar.types.ts
+++ b/src/components/menubar/menubar.types.ts
@@ -7,6 +7,7 @@ import type {
 import type { OverlayAlign, OverlaySide } from '../_internal/overlay';
 
 export type MenubarOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   loop?: boolean;
@@ -16,6 +17,7 @@ export type MenubarProps = BoxProps<'div', HTMLDivElement> & MenubarOwnProps;
 
 export type MenubarMenuProps = {
   children?: unknown;
+  /** Stable and unique among sibling menus when menus are rendered dynamically. */
   value?: string;
 };
 

--- a/src/components/radio-group/radio-group.types.ts
+++ b/src/components/radio-group/radio-group.types.ts
@@ -10,6 +10,7 @@ export type RadioGroupOwnProps = {
   name?: string;
   orientation?: Orientation;
   loop?: boolean;
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
 };
 

--- a/src/components/select/select.types.ts
+++ b/src/components/select/select.types.ts
@@ -7,6 +7,7 @@ import type {
 import type { OverlayAlign, OverlaySide } from '../_internal/overlay';
 
 export type SelectOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   value?: string;

--- a/src/components/slider/slider.types.ts
+++ b/src/components/slider/slider.types.ts
@@ -3,6 +3,7 @@ import type { BoxAsChildProps, BoxProps } from '../_internal/types';
 export type SliderOrientation = 'horizontal' | 'vertical';
 
 export type SliderOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   value?: number;

--- a/src/components/toggle-group/toggle-group.types.ts
+++ b/src/components/toggle-group/toggle-group.types.ts
@@ -7,6 +7,7 @@ import type {
 export type ToggleGroupOrientation = 'horizontal' | 'vertical';
 
 type ToggleGroupSharedOwnProps = {
+  /** Supports literal, nested, array-mapped, and `For`-rendered descendants. */
   children?: unknown;
   id?: string;
   orientation?: ToggleGroupOrientation;

--- a/tests/browser/components/dynamic-children/behavior.test.tsx
+++ b/tests/browser/components/dynamic-children/behavior.test.tsx
@@ -1,0 +1,443 @@
+import { For, state } from '@askrjs/askr';
+import { afterEach, describe, expect, it } from 'vite-plus/test';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionHeader,
+  AccordionItem,
+  AccordionTrigger,
+} from '../../../../src/components/accordion';
+import {
+  Dropdown,
+  DropdownContent,
+  DropdownItem,
+  DropdownTrigger,
+} from '../../../../src/components/dropdown';
+import { Menu, MenuContent, MenuItem } from '../../../../src/components/menu';
+import {
+  Menubar,
+  MenubarContent,
+  MenubarItem,
+  MenubarMenu,
+  MenubarPortal,
+  MenubarTrigger,
+} from '../../../../src/components/menubar';
+import {
+  RadioGroup,
+  RadioGroupItem,
+} from '../../../../src/components/radio-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '../../../../src/components/select';
+import {
+  Slider,
+  SliderRange,
+  SliderThumb,
+  SliderTrack,
+} from '../../../../src/components/slider';
+import { flushUpdates, mount, unmount } from '../../test-utils';
+
+const ITEMS = [
+  { value: 'one', label: 'One' },
+  { value: 'two', label: 'Two' },
+] as const;
+
+type DynamicMode = 'map' | 'for';
+
+function DynamicItems<T>(props: {
+  mode: DynamicMode;
+  each: readonly T[];
+  by: (item: T, index: number) => string | number;
+  children: (item: T) => JSX.Element;
+}) {
+  return props.mode === 'map' ? (
+    props.each.map(props.children)
+  ) : (
+    <For each={props.each} by={props.by}>
+      {props.children}
+    </For>
+  );
+}
+
+function modes() {
+  return ['map', 'for'] as const;
+}
+
+describe('dynamic children context contract', () => {
+  let container: HTMLElement | undefined;
+
+  afterEach(() => {
+    unmount(container);
+    container = undefined;
+  });
+
+  it('should support mapped and For-rendered Accordion items', async () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <Accordion key={mode} defaultValue="one">
+            <DynamicItems mode={mode} each={ITEMS} by={(item) => item.value}>
+              {(item) => (
+                <AccordionItem key={item.value} value={item.value}>
+                  <AccordionHeader>
+                    <AccordionTrigger>
+                      {item.label} {mode}
+                    </AccordionTrigger>
+                  </AccordionHeader>
+                  <AccordionContent>{item.label} content</AccordionContent>
+                </AccordionItem>
+              )}
+            </DynamicItems>
+          </Accordion>
+        ))}
+      </div>
+    );
+
+    for (const mode of modes()) {
+      const trigger = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === `Two ${mode}`
+      );
+      trigger?.click();
+    }
+    await flushUpdates();
+
+    for (const mode of modes()) {
+      const trigger = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === `Two ${mode}`
+      );
+      expect(trigger?.getAttribute('aria-expanded')).toBe('true');
+    }
+  });
+
+  it('should support mapped and For-rendered RadioGroup items', async () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <RadioGroup key={mode} defaultValue="one">
+            <DynamicItems mode={mode} each={ITEMS} by={(item) => item.value}>
+              {(item) => (
+                <RadioGroupItem key={item.value} value={item.value}>
+                  {item.label} {mode}
+                </RadioGroupItem>
+              )}
+            </DynamicItems>
+          </RadioGroup>
+        ))}
+      </div>
+    );
+
+    for (const mode of modes()) {
+      const item = Array.from(
+        container.querySelectorAll('[role="radio"]')
+      ).find((radio) => radio.textContent?.trim() === `Two ${mode}`);
+      (item as HTMLElement | undefined)?.click();
+    }
+    await flushUpdates();
+
+    for (const mode of modes()) {
+      const item = Array.from(
+        container.querySelectorAll('[role="radio"]')
+      ).find((radio) => radio.textContent?.trim() === `Two ${mode}`);
+      expect(item?.getAttribute('aria-checked')).toBe('true');
+    }
+  });
+
+  it('should support mapped and For-rendered Menu items', () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <Menu key={mode}>
+            <MenuContent>
+              <DynamicItems mode={mode} each={ITEMS} by={(item) => item.value}>
+                {(item) => (
+                  <MenuItem key={item.value}>
+                    {item.label} {mode}
+                  </MenuItem>
+                )}
+              </DynamicItems>
+            </MenuContent>
+          </Menu>
+        ))}
+      </div>
+    );
+
+    for (const mode of modes()) {
+      const items = Array.from(
+        container.querySelectorAll('[role="menuitem"]')
+      ).filter((item) => item.textContent?.endsWith(mode));
+      expect(items).toHaveLength(2);
+      expect(items.map((item) => item.getAttribute('tabindex'))).toEqual([
+        '0',
+        '-1',
+      ]);
+    }
+  });
+
+  it('should support mapped and For-rendered Dropdown items', async () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <Dropdown key={mode} defaultOpen>
+            <DropdownTrigger>Open {mode}</DropdownTrigger>
+            <DropdownContent forceMount>
+              <DynamicItems mode={mode} each={ITEMS} by={(item) => item.value}>
+                {(item) => (
+                  <DropdownItem key={item.value}>
+                    {item.label} {mode}
+                  </DropdownItem>
+                )}
+              </DynamicItems>
+            </DropdownContent>
+          </Dropdown>
+        ))}
+      </div>
+    );
+    await flushUpdates();
+
+    for (const mode of modes()) {
+      const items = Array.from(
+        container.querySelectorAll('[role="menuitem"]')
+      ).filter((item) => item.textContent?.endsWith(mode));
+      expect(items).toHaveLength(2);
+      expect(items.map((item) => item.getAttribute('tabindex'))).toEqual([
+        '0',
+        '-1',
+      ]);
+    }
+  });
+
+  it('should support mapped and For-rendered Select items', async () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <Select key={mode} defaultValue="one" name={mode}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent forceMount>
+              <DynamicItems mode={mode} each={ITEMS} by={(item) => item.value}>
+                {(item) => (
+                  <SelectItem
+                    key={item.value}
+                    value={item.value}
+                    textValue={`${item.label} ${mode}`}
+                  >
+                    {item.label} {mode}
+                  </SelectItem>
+                )}
+              </DynamicItems>
+            </SelectContent>
+          </Select>
+        ))}
+      </div>
+    );
+
+    for (const mode of modes()) {
+      const item = Array.from(
+        container.querySelectorAll('[role="option"]')
+      ).find((option) => option.textContent?.trim() === `Two ${mode}`);
+      (item as HTMLElement | undefined)?.click();
+    }
+    await flushUpdates();
+
+    for (const mode of modes()) {
+      const input = container.querySelector(
+        `input[name="${mode}"]`
+      ) as HTMLInputElement;
+      expect(input.value).toBe('two');
+    }
+  });
+
+  it('should support mapped and For-rendered Menubar menus and items', async () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <Menubar key={mode}>
+            <DynamicItems mode={mode} each={ITEMS} by={(item) => item.value}>
+              {(menu) => (
+                <MenubarMenu key={menu.value} value={menu.value}>
+                  <MenubarTrigger>
+                    {menu.label} {mode}
+                  </MenubarTrigger>
+                  <MenubarPortal>
+                    <MenubarContent forceMount>
+                      <DynamicItems
+                        mode={mode}
+                        each={ITEMS}
+                        by={(item) => item.value}
+                      >
+                        {(item) => (
+                          <MenubarItem key={item.value}>
+                            {menu.label} {item.label} action {mode}
+                          </MenubarItem>
+                        )}
+                      </DynamicItems>
+                    </MenubarContent>
+                  </MenubarPortal>
+                </MenubarMenu>
+              )}
+            </DynamicItems>
+          </Menubar>
+        ))}
+      </div>
+    );
+
+    for (const mode of modes()) {
+      const trigger = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent?.trim() === `Two ${mode}`
+      );
+      trigger?.click();
+    }
+    await flushUpdates();
+    await flushUpdates();
+    await flushUpdates();
+
+    for (const mode of modes()) {
+      const triggers = Array.from(
+        container.querySelectorAll('[role="menuitem"]')
+      ).filter(
+        (item) =>
+          item.textContent?.endsWith(mode) &&
+          !item.textContent.includes('action')
+      );
+      const actions = Array.from(
+        document.body.querySelectorAll('[role="menuitem"]')
+      ).filter(
+        (item) =>
+          item.textContent?.startsWith('Two ') &&
+          item.textContent.endsWith(`action ${mode}`)
+      );
+      expect(triggers).toHaveLength(2);
+      expect(actions).toHaveLength(2);
+      expect(
+        document.body.textContent?.includes(`One One action ${mode}`)
+      ).toBe(false);
+    }
+  });
+
+  it('should keep dynamic Menubar identities stable across reorder and removal', async () => {
+    const initialMenus = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'beta', label: 'Beta' },
+    ];
+    let setMenus:
+      | ((next: Array<{ value: string; label: string }>) => void)
+      | undefined;
+
+    function DynamicMenubar() {
+      const menus = state(initialMenus);
+      setMenus = menus.set;
+
+      return (
+        <Menubar>
+          {menus().map((menu) => (
+            <MenubarMenu key={menu.value} value={menu.value}>
+              <MenubarTrigger>{menu.label}</MenubarTrigger>
+              <MenubarPortal>
+                <MenubarContent>
+                  <MenubarItem>{menu.label} action</MenubarItem>
+                </MenubarContent>
+              </MenubarPortal>
+            </MenubarMenu>
+          ))}
+        </Menubar>
+      );
+    }
+
+    container = mount(<DynamicMenubar />);
+    await flushUpdates();
+
+    const getTrigger = (label: string) =>
+      Array.from(container?.querySelectorAll('button') ?? []).find(
+        (button) => button.textContent?.trim() === label
+      ) as HTMLButtonElement;
+    const initialControls = {
+      alpha: getTrigger('Alpha').getAttribute('aria-controls'),
+      beta: getTrigger('Beta').getAttribute('aria-controls'),
+    };
+
+    expect(initialControls.alpha).not.toBe(initialControls.beta);
+
+    getTrigger('Beta').click();
+    await flushUpdates();
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.body.textContent).toContain('Beta action');
+    expect(document.body.textContent).not.toContain('Alpha action');
+
+    setMenus?.([initialMenus[1]!, initialMenus[0]!]);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(getTrigger('Alpha').getAttribute('aria-controls')).toBe(
+      initialControls.alpha
+    );
+    expect(getTrigger('Beta').getAttribute('aria-controls')).toBe(
+      initialControls.beta
+    );
+    expect(document.body.textContent).toContain('Beta action');
+
+    setMenus?.([initialMenus[0]!]);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(getTrigger('Alpha').getAttribute('aria-controls')).toBe(
+      initialControls.alpha
+    );
+    expect(document.body.textContent).not.toContain('Beta action');
+
+    setMenus?.(initialMenus);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(getTrigger('Alpha').getAttribute('aria-controls')).toBe(
+      initialControls.alpha
+    );
+    expect(getTrigger('Beta').getAttribute('aria-controls')).toBe(
+      initialControls.beta
+    );
+  });
+
+  it('should reject duplicate dynamic Menubar values', () => {
+    expect(() => {
+      container = mount(
+        <Menubar>
+          {['First', 'Second'].map((label) => (
+            <MenubarMenu key={label} value="duplicate">
+              <MenubarTrigger>{label}</MenubarTrigger>
+            </MenubarMenu>
+          ))}
+        </Menubar>
+      );
+    }).toThrow(/MenubarMenu values must be unique/);
+  });
+
+  it('should support mapped and For-rendered Slider parts', () => {
+    container = mount(
+      <div>
+        {modes().map((mode) => (
+          <Slider key={mode} defaultValue={25}>
+            <DynamicItems mode={mode} each={['track']} by={(part) => part}>
+              {() => (
+                <SliderTrack key="track">
+                  <SliderRange />
+                  <SliderThumb aria-label={`${mode} value`} />
+                </SliderTrack>
+              )}
+            </DynamicItems>
+          </Slider>
+        ))}
+      </div>
+    );
+
+    for (const mode of modes()) {
+      const thumb = container.querySelector(`[aria-label="${mode} value"]`);
+      expect(thumb?.getAttribute('aria-valuenow')).toBe('25');
+    }
+  });
+});

--- a/tests/unit/dynamic-children-contract.test.ts
+++ b/tests/unit/dynamic-children-contract.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+const GROUP_FAMILIES = [
+  'accordion',
+  'dropdown',
+  'menu',
+  'menubar',
+  'radio-group',
+  'select',
+  'slider',
+  'toggle-group',
+] as const;
+
+const DYNAMIC_CHILDREN_TYPE_DOC =
+  'Supports literal, nested, array-mapped, and `For`-rendered descendants.';
+
+describe('dynamic children public contract', () => {
+  it('should document every context-coordinated group family', () => {
+    const docs = readFileSync(
+      join(process.cwd(), 'docs', 'components.md'),
+      'utf8'
+    );
+
+    for (const family of GROUP_FAMILIES) {
+      expect(docs).toContain(`| \`${family}\``);
+    }
+
+    expect(docs).toContain(
+      'Dynamic descendants are a supported composition contract'
+    );
+    const dynamicDescendantsSection = docs
+      .split('## Dynamic descendants')[1]
+      ?.split('\n## ')[0];
+    expect(dynamicDescendantsSection).toBeDefined();
+    expect(dynamicDescendantsSection).not.toContain('literal children only');
+  });
+
+  it('should keep dynamic descendant support visible in root prop type docs', () => {
+    for (const family of GROUP_FAMILIES) {
+      const types = readFileSync(
+        join(process.cwd(), 'src', 'components', family, `${family}.types.ts`),
+        'utf8'
+      );
+
+      expect(types, family).toContain(DYNAMIC_CHILDREN_TYPE_DOC);
+    }
+  });
+});

--- a/vitest.test.unit.config.ts
+++ b/vitest.test.unit.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       'tests/unit/react-free-public-surface.test.ts',
       'tests/unit/export-map.test.ts',
       'tests/unit/docs-contract.test.ts',
+      'tests/unit/dynamic-children-contract.test.ts',
     ],
   },
 });


### PR DESCRIPTION
## Summary

- document dynamic descendants as a supported contract for all eight context-coordinated group families
- add shared `.map()` and `<For>` browser contracts for Accordion, Dropdown, Menu, Menubar, RadioGroup, Select, Slider, and ToggleGroup coverage
- replace Menubar static child pre-counting with stable value-keyed portal records so dynamic menus open the correct content through reorder and removal
- keep generated Menubar IDs stable across rerenders and publish the type-doc contract
- bump `@askrjs/ui` to 0.0.20

## Regression coverage

- mapped and `<For>` descendants retain context in every audited group family
- dynamic Menubar menus open only their matching portal content
- Menubar trigger/content identities remain unique and stable across rerender, reorder, removal, and reinsertion
- existing literal Menubar behavior, accessibility, and determinism suites remain green
- docs and root prop types must retain the positive dynamic-descendant contract

## Validation

- `npm run fmt -- --check`
- `npm run check`
- `npm run bench`

Closes #16