### PR TITLE
test: backfill Form, HoverCard, and ScrollArea contracts

### DIFF
--- a/src/components/form/form.types.ts
+++ b/src/components/form/form.types.ts
@@ -1,4 +1,4 @@
-import type { BoxAsChildProps, BoxProps } from '../_internal/types';
+import type { BoxProps } from '../_internal/types';
 
 export type FormOwnProps = {
   children?: unknown;
@@ -6,4 +6,16 @@ export type FormOwnProps = {
 
 export type FormProps = BoxProps<'form', HTMLFormElement> & FormOwnProps;
 
-export type FormAsChildProps = BoxAsChildProps & FormOwnProps;
+/**
+ * `asChild` keeps the form host supplied by the consumer, while retaining the
+ * native form attribute contract (method, action, target, encoding, etc.).
+ */
+export type FormAsChildProps = Omit<
+  JSX.IntrinsicElements['form'],
+  'children' | 'ref'
+> &
+  FormOwnProps & {
+    asChild: true;
+    children: JSX.Element;
+    ref?: import('@askrjs/askr/foundations/utilities').Ref<Element>;
+  };

--- a/src/components/hover-card/hover-card-content.tsx
+++ b/src/components/hover-card/hover-card-content.tsx
@@ -55,6 +55,10 @@ export function HoverCardContent(
     ),
     id: root.contentId,
     role: 'dialog',
+    // A HoverCard is an interactive dialog tied to its trigger.  Exposing the
+    // trigger as the accessible name keeps the relationship intact for both
+    // the inline and portal-rendered content paths.
+    'aria-labelledby': root.triggerId,
     tabIndex: -1,
     'data-slot': 'hover-card-content',
     'data-state': root.open ? 'open' : 'closed',

--- a/src/components/scroll-area/scroll-area.tsx
+++ b/src/components/scroll-area/scroll-area.tsx
@@ -73,6 +73,8 @@ export function ScrollAreaViewport(
   const finalProps = mergeProps(rest, {
     ref,
     id: root.viewportId,
+    role: 'region',
+    tabIndex: 0,
     'data-slot': 'scroll-area-viewport',
   });
 
@@ -97,10 +99,13 @@ export function ScrollAreaScrollbar(
   const finalProps = mergeProps(rest, {
     ref,
     id: root.scrollbarId,
+    role: 'scrollbar',
+    'aria-controls': root.viewportId,
+    'aria-orientation': orientation,
+    tabIndex: 0,
     'data-slot': 'scroll-area-scrollbar',
     'data-orientation': orientation,
     'data-state': 'visible',
-    'aria-hidden': 'true',
   });
 
   return <div {...finalProps}>{children}</div>;

--- a/tests/browser/components/form/behavior.test.tsx
+++ b/tests/browser/components/form/behavior.test.tsx
@@ -53,7 +53,9 @@ describe('Form - Behavior', () => {
     const form = container.querySelector('form') as HTMLFormElement;
     const input = container.querySelector('input') as HTMLInputElement;
     input.value = 'Grace';
-    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    form.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
     form.dispatchEvent(new Event('reset', { bubbles: true }));
     await flushUpdates();
     expect(onSubmit).toHaveBeenCalledOnce();
@@ -62,7 +64,13 @@ describe('Form - Behavior', () => {
 
   it('should preserve form attributes given Form asChild when method, action, target, and encoding props are supplied', async () => {
     container = mount(
-      <Form asChild method="post" action="/save" target="_blank" encType="multipart/form-data">
+      <Form
+        asChild
+        method="post"
+        action="/save"
+        target="_blank"
+        encType="multipart/form-data"
+      >
         <section>Fields</section>
       </Form>
     );

--- a/tests/browser/components/form/behavior.test.tsx
+++ b/tests/browser/components/form/behavior.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { Form } from '../../../../src/components/form';
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
@@ -37,5 +37,40 @@ describe('Form - Behavior', () => {
     const section = container.querySelector('section') as HTMLElement | null;
 
     expect(section?.getAttribute('data-slot')).toBe('form');
+  });
+
+  it('should submit and reset native controls given Form defaults when submit and reset events occur', async () => {
+    const onSubmit = vi.fn((event: Event) => event.preventDefault());
+    const onReset = vi.fn();
+    container = mount(
+      <Form onSubmit={onSubmit} onReset={onReset}>
+        <input name="name" defaultValue="Ada" />
+        <button type="submit">Save</button>
+        <button type="reset">Reset</button>
+      </Form>
+    );
+    await flushUpdates();
+    const form = container.querySelector('form') as HTMLFormElement;
+    const input = container.querySelector('input') as HTMLInputElement;
+    input.value = 'Grace';
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    form.dispatchEvent(new Event('reset', { bubbles: true }));
+    await flushUpdates();
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('should preserve form attributes given Form asChild when method, action, target, and encoding props are supplied', async () => {
+    container = mount(
+      <Form asChild method="post" action="/save" target="_blank" encType="multipart/form-data">
+        <section>Fields</section>
+      </Form>
+    );
+    await flushUpdates();
+    const section = container.querySelector('section') as HTMLElement;
+    expect(section.getAttribute('method')).toBe('post');
+    expect(section.getAttribute('action')).toBe('/save');
+    expect(section.getAttribute('target')).toBe('_blank');
+    expect(section.getAttribute('enctype')).toBe('multipart/form-data');
   });
 });

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -85,4 +85,52 @@ describe('HoverCard - Behavior', () => {
     expect(triggerRef.current).toBe(trigger);
     expect(contentRef.current).toBe(content);
   });
+
+  it('should preserve controlled open state given open and onOpenChange when hover and focus events interleave', async () => {
+    vi.useFakeTimers();
+    const onOpenChange = vi.fn();
+    container = mount(
+      <HoverCard open={false} onOpenChange={onOpenChange}>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+    const trigger = container.querySelector('[data-slot="hover-card-trigger"]') as HTMLElement;
+    trigger.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    await flushUpdates();
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(trigger.getAttribute('data-state')).toBe('closed');
+  });
+
+  it('should cancel delayed close given pointer movement from trigger to content when the close timer is pending', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <HoverCard defaultOpen closeDelay={50}>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+    await flushUpdates();
+    const trigger = container.querySelector('[data-slot="hover-card-trigger"]') as HTMLElement;
+    const content = document.body.querySelector('[data-slot="hover-card-content"]') as HTMLElement;
+    trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+    content.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(60);
+    await flushUpdates();
+    expect(document.body.querySelector('[data-slot="hover-card-content"]')).not.toBeNull();
+  });
+
+  it('should expose complete dialog labeling given a trigger and content when the card is open', async () => {
+    container = mount(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+    await flushUpdates();
+    const trigger = container.querySelector('[data-slot="hover-card-trigger"]') as HTMLElement;
+    const content = document.body.querySelector('[data-slot="hover-card-content"]') as HTMLElement;
+    expect(content.getAttribute('role')).toBe('dialog');
+    expect(content.getAttribute('aria-labelledby')).toBe(trigger.id);
+  });
 });

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -95,7 +95,9 @@ describe('HoverCard - Behavior', () => {
         <HoverCardContent>Details</HoverCardContent>
       </HoverCard>
     );
-    const trigger = container.querySelector('[data-slot="hover-card-trigger"]') as HTMLElement;
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
     trigger.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
     await flushUpdates();
     expect(onOpenChange).toHaveBeenCalledWith(true);
@@ -111,13 +113,19 @@ describe('HoverCard - Behavior', () => {
       </HoverCard>
     );
     await flushUpdates();
-    const trigger = container.querySelector('[data-slot="hover-card-trigger"]') as HTMLElement;
-    const content = document.body.querySelector('[data-slot="hover-card-content"]') as HTMLElement;
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    const content = document.body.querySelector(
+      '[data-slot="hover-card-content"]'
+    ) as HTMLElement;
     trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
     content.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
     await vi.advanceTimersByTimeAsync(60);
     await flushUpdates();
-    expect(document.body.querySelector('[data-slot="hover-card-content"]')).not.toBeNull();
+    expect(
+      document.body.querySelector('[data-slot="hover-card-content"]')
+    ).not.toBeNull();
   });
 
   it('should expose complete dialog labeling given a trigger and content when the card is open', async () => {
@@ -128,8 +136,12 @@ describe('HoverCard - Behavior', () => {
       </HoverCard>
     );
     await flushUpdates();
-    const trigger = container.querySelector('[data-slot="hover-card-trigger"]') as HTMLElement;
-    const content = document.body.querySelector('[data-slot="hover-card-content"]') as HTMLElement;
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    const content = document.body.querySelector(
+      '[data-slot="hover-card-content"]'
+    ) as HTMLElement;
     expect(content.getAttribute('role')).toBe('dialog');
     expect(content.getAttribute('aria-labelledby')).toBe(trigger.id);
   });

--- a/tests/browser/components/scroll-area/behavior.test.tsx
+++ b/tests/browser/components/scroll-area/behavior.test.tsx
@@ -83,12 +83,24 @@ describe('ScrollArea - Behavior', () => {
       </ScrollArea>
     );
     await flushUpdates();
-    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement;
-    const bars = [...container.querySelectorAll('[data-slot="scroll-area-scrollbar"]')] as HTMLElement[];
+    const viewport = container.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    ) as HTMLElement;
+    const bars = [
+      ...container.querySelectorAll('[data-slot="scroll-area-scrollbar"]'),
+    ] as HTMLElement[];
     expect(viewport.getAttribute('role')).toBe('region');
-    expect(bars.map((bar) => bar.getAttribute('role'))).toEqual(['scrollbar', 'scrollbar']);
-    expect(bars.map((bar) => bar.getAttribute('aria-orientation'))).toEqual(['vertical', 'horizontal']);
-    expect(bars.every((bar) => bar.getAttribute('aria-controls') === viewport.id)).toBe(true);
+    expect(bars.map((bar) => bar.getAttribute('role'))).toEqual([
+      'scrollbar',
+      'scrollbar',
+    ]);
+    expect(bars.map((bar) => bar.getAttribute('aria-orientation'))).toEqual([
+      'vertical',
+      'horizontal',
+    ]);
+    expect(
+      bars.every((bar) => bar.getAttribute('aria-controls') === viewport.id)
+    ).toBe(true);
   });
 
   it('should preserve consumer scroll handlers and refs given ScrollAreaViewport asChild when the viewport rerenders', async () => {
@@ -102,7 +114,9 @@ describe('ScrollArea - Behavior', () => {
       </ScrollArea>
     );
     await flushUpdates();
-    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]') as HTMLDivElement;
+    const viewport = container.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    ) as HTMLDivElement;
     viewport.dispatchEvent(new Event('scroll', { bubbles: true }));
     expect(ref.current).toBe(viewport);
     expect(onScroll).toHaveBeenCalledOnce();

--- a/tests/browser/components/scroll-area/behavior.test.tsx
+++ b/tests/browser/components/scroll-area/behavior.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   ScrollArea,
   ScrollAreaCorner,
@@ -72,5 +72,39 @@ describe('ScrollArea - Behavior', () => {
         children: <div>Orphan</div>,
       } as never)
     ).toThrowError(/called during component render/);
+  });
+
+  it('should expose viewport and scrollbar accessibility semantics given vertical and horizontal orientations when the area mounts', async () => {
+    container = mount(
+      <ScrollArea id="messages">
+        <ScrollAreaViewport>Messages</ScrollAreaViewport>
+        <ScrollAreaScrollbar orientation="vertical" />
+        <ScrollAreaScrollbar orientation="horizontal" />
+      </ScrollArea>
+    );
+    await flushUpdates();
+    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]') as HTMLElement;
+    const bars = [...container.querySelectorAll('[data-slot="scroll-area-scrollbar"]')] as HTMLElement[];
+    expect(viewport.getAttribute('role')).toBe('region');
+    expect(bars.map((bar) => bar.getAttribute('role'))).toEqual(['scrollbar', 'scrollbar']);
+    expect(bars.map((bar) => bar.getAttribute('aria-orientation'))).toEqual(['vertical', 'horizontal']);
+    expect(bars.every((bar) => bar.getAttribute('aria-controls') === viewport.id)).toBe(true);
+  });
+
+  it('should preserve consumer scroll handlers and refs given ScrollAreaViewport asChild when the viewport rerenders', async () => {
+    const onScroll = vi.fn();
+    const ref = { current: null as HTMLDivElement | null };
+    container = mount(
+      <ScrollArea>
+        <ScrollAreaViewport asChild ref={ref} onScroll={onScroll}>
+          <div>Messages</div>
+        </ScrollAreaViewport>
+      </ScrollArea>
+    );
+    await flushUpdates();
+    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]') as HTMLDivElement;
+    viewport.dispatchEvent(new Event('scroll', { bubbles: true }));
+    expect(ref.current).toBe(viewport);
+    expect(onScroll).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary

Backfills behavior and accessibility coverage for Form, HoverCard, and ScrollArea, with corresponding semantic fixes.

## Checklist

- [x] Form native submit/reset and asChild attribute preservation
- [x] HoverCard controlled state, pointer handoff, and dialog labeling
- [x] ScrollArea viewport/scrollbar semantics and asChild handler/ref preservation
- [ ] Cross-component controls/overlays/virtualization/hydration (#26) remains separate

Closes #23
Closes #24
Closes #25