### PR TITLE
refactor: publish npm package directly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@eba6e4d2ef1fb9a13d620fe781175015b1225964
+    uses: askrjs/actions/.github/workflows/publish-package.yml@d3c866509a8245456fcd6fd929d5493737beddde
     with:
       install-playwright: true
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@3917142edc5c6534616b28094322c9107aac6f86
+    uses: askrjs/actions/.github/workflows/publish-package.yml@eba6e4d2ef1fb9a13d620fe781175015b1225964
     with:
       install-playwright: true
     permissions:


### PR DESCRIPTION
Pins the shared release workflow after removing the publish composite action. Publication now uses the explicit one-line npm publish --provenance --access public command, while retaining browser installation in both release jobs.