### PR TITLE
fix: harden component keyboard interactions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,8 @@
 *.ts text eol=lf
 *.tsx text eol=lf
 *.js text eol=lf
+*.mjs text eol=lf
+*.cjs text eol=lf
 *.jsx text eol=lf
 *.json text eol=lf
 *.yml text eol=lf

--- a/benches/tier4/navigation.browser.bench.tsx
+++ b/benches/tier4/navigation.browser.bench.tsx
@@ -1,0 +1,75 @@
+import { bench, describe } from 'vite-plus/test';
+import { Menu, MenuContent, MenuItem } from '../../src/components/menu';
+import { getTabbableElements } from '../../src/components/_internal/focus';
+import {
+  createTier4BenchOptions,
+  flushBrowserBenchUpdates,
+  runBrowserBench,
+} from './browser-bench';
+
+const itemCount = 200;
+const navigationBenchOptions = createTier4BenchOptions({
+  time: 1000,
+  warmupTime: 250,
+});
+
+describe('Focus-order traversal benches', () => {
+  bench(
+    'flatten 1k mixed light and shadow focus stops',
+    () => {
+      const root = document.createElement('div');
+      for (let index = 0; index < 1000; index += 1) {
+        if (index % 10 === 0) {
+          const host = document.createElement('div');
+          host.attachShadow({ mode: 'open' }).innerHTML =
+            '<button>Shadow stop</button>';
+          root.append(host);
+        } else {
+          const button = document.createElement('button');
+          button.textContent = `Stop ${index}`;
+          root.append(button);
+        }
+      }
+      document.body.append(root);
+      getTabbableElements(root);
+      root.remove();
+    },
+    navigationBenchOptions
+  );
+});
+
+describe('Typeahead benches', () => {
+  bench(
+    'match within a 200-item rendered menu',
+    async () => {
+      await runBrowserBench(
+        <Menu>
+          <MenuContent>
+            {Array.from({ length: itemCount }, (_, index) => (
+              <MenuItem
+                key={index}
+                index={index}
+                textValue={`Database ${index}`}
+              >
+                Database {index}
+              </MenuItem>
+            ))}
+          </MenuContent>
+        </Menu>,
+        async (container) => {
+          const menu = container.querySelector('[role="menu"]') as HTMLElement;
+          menu.focus();
+          menu.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'D',
+              bubbles: true,
+              cancelable: true,
+            })
+          );
+          await flushBrowserBenchUpdates();
+        }
+      );
+    },
+    navigationBenchOptions
+  );
+});

--- a/docs/components.md
+++ b/docs/components.md
@@ -34,7 +34,7 @@ These are documentation groupings only.
 | Disclosure                 | Accordion, Collapsible                                                                                                                                   |
 | Status                     | Progress, ProgressCircle, Toast                                                                                                                          |
 | Identity                   | Avatar                                                                                                                                                   |
-| Navigation                 | Menubar, Navigation Menu                                                                                                                                 |
+| Navigation                 | Menubar                                                                                                                                                  |
 | Layout and layout-adjacent | Scroll Area                                                                                                                                              |
 | Virtualization             | VirtualList, VirtualTable                                                                                                                                |
 
@@ -58,6 +58,37 @@ These are documentation groupings only.
   anchor correction, and optional follow-bottom behavior.
 - `VirtualTable` is a fixed-height table windowing primitive with a sticky
   head, stable keys, selection, and keyboard navigation.
+
+## Keyboard interaction
+
+Keyboard behavior follows the semantic role of each public component and is
+preserved through `asChild` composition.
+
+| Surface                             | Keyboard contract                                                                                                                                                                                                           |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pressable controls                  | `Enter` activates on keydown, `Space` activates on keyup, disabled controls do not activate, and caller cancellation still suppresses the component's default action.                                                       |
+| Roving composites                   | Arrow keys move the single active tab stop and skip disabled items. `Tab` leaves the composite or dismisses an open popup and continues to the next page control.                                                           |
+| Menu, Dropdown, Menubar, and Select | Printable keys perform case-insensitive prefix matching against `textValue` (or rendered text), skip disabled items, wrap to the next match, and cycle when the same character is repeated. The buffer resets after 500 ms. |
+| Select                              | Typeahead works while either the closed trigger or open listbox has focus. Closed-trigger matches update the value; open-listbox matches move focus.                                                                        |
+| Accordion                           | Every enabled trigger remains in the page Tab sequence. Orientation arrows and Home/End provide optional direct navigation.                                                                                                 |
+| RadioGroup                          | Arrows skip disabled radios and move focus and selection.                                                                                                                                                                   |
+| ToggleGroup                         | Arrows move focus only; Enter or Space activates the focused toggle.                                                                                                                                                        |
+| ScrollArea                          | Its enabled scrollbar uses arrows for 40 CSS-pixel steps, PageUp/PageDown for one viewport, and Home/End for the boundaries.                                                                                                |
+
+Spaces typed after a typeahead prefix can match multiword values; a standalone
+`Space` remains an activation key. Typeahead only moves focus or selection. A
+visible text field that filters options is a separate Combobox capability, not
+Select behavior.
+
+Native buttons and direct `asChild` buttons retain browser activation and form
+submit/reset behavior. Non-native `asChild` hosts receive button-role
+Enter/Space behavior. Component defaults run only when neither an ancestor nor
+the caller canceled the event; activation remains exactly once in either path.
+Menu-item links preserve native Enter navigation, while Space maps to one click.
+
+HoverCard is a non-modal interactive preview. Pointer opening does not move
+focus. Tab can enter its content from the trigger, Escape restores the trigger,
+and leaving its final control continues after the trigger.
 
 ## Dynamic descendants
 

--- a/docs/regression-coverage.md
+++ b/docs/regression-coverage.md
@@ -18,23 +18,23 @@ here.
 
 ## Regression classes
 
-| Class                                 | Required durable coverage                                                                                                                                                                                          |
-| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Stale event/context snapshots         | Repeated user interactions after rerender must assert current DOM state and callback payloads, especially controlled/uncontrolled components.                                                                      |
-| Timer and microtask sensitivity       | Fake-timer tests must not rely on `setTimeout(0)` helpers; behavior tests should use deterministic flush helpers or fake timers.                                                                                   |
-| Render-time state writes              | Ref callbacks and virtualized mount paths must defer state writes; behavior tests should assert no render-time state errors.                                                                                       |
-| Controlled/uncontrolled normalization | Single and multiple value APIs must assert callback payloads, DOM state, and controlled non-mutation behavior.                                                                                                     |
-| Async media/status transitions        | Load and error paths must assert fallback/presence state after real browser events.                                                                                                                                |
-| Portal and focus cleanup              | Overlays, toasts, dialogs, menus, and popovers must assert dismissal, focus restoration, and teardown.                                                                                                             |
-| Export/version drift                  | Root exports, ESM subpath exports, and type tests must fail before a downstream package consumes a broken surface. CJS runtime loading is not part of the current release gate because `@askrjs/askr` is ESM-only. |
+| Class                                 | Required durable coverage                                                                                                                                                                                                                                        |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Stale event/context snapshots         | Repeated user interactions after rerender must assert current DOM state and callback payloads, especially controlled/uncontrolled components.                                                                                                                    |
+| Timer and microtask sensitivity       | Fake-timer tests must not rely on `setTimeout(0)` helpers; behavior tests should use deterministic flush helpers or fake timers.                                                                                                                                 |
+| Render-time state writes              | Ref callbacks and virtualized mount paths must defer state writes; behavior tests should assert no render-time state errors.                                                                                                                                     |
+| Controlled/uncontrolled normalization | Single and multiple value APIs must assert callback payloads, DOM state, and controlled non-mutation behavior.                                                                                                                                                   |
+| Async media/status transitions        | Load and error paths must assert fallback/presence state after real browser events.                                                                                                                                                                              |
+| Portal and focus cleanup              | Overlays, toasts, dialogs, menus, and popovers must assert dismissal, focus restoration, and teardown.                                                                                                                                                           |
+| Composite keyboard interaction        | Applicable families must cover `Tab`, `Enter`, `Space`, arrow navigation, `asChild`, and disabled-item behavior. Menu and listbox families must also cover case-insensitive `textValue` matching, repeated-key cycling, full-prefix buffering, and buffer reset. |
+| Export/version drift                  | Root exports, ESM subpath exports, and type tests must fail before a downstream package consumes a broken surface. CJS runtime loading is not part of the current release gate because `@askrjs/askr` is ESM-only.                                               |
 
 ## Current focused follow-ups
 
 - Slider, toast, avatar, virtual list, virtual table, and toggle group regressions
   are covered by the current browser suites.
-- `form` and `scroll-area` intentionally have behavior-only browser coverage
-  today; add a11y and determinism tests before broadening their behavior
-  surface.
+- Form, ScrollArea, and HoverCard have behavior, accessibility, and
+  determinism coverage.
 - New component families must add behavior, a11y, determinism, public API, and
   benchmark coverage before release unless this ledger records a narrower
   contract.

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "test:types": "tsc -p tsconfig.type-tests.json --noEmit",
     "test:unit": "npm run test:types && vp test run --config vitest.test.unit.config.ts",
     "test:publint": "publint",
-    "pack:check": "npm pack --ignore-scripts --dry-run --json",
+    "pack:check": "node scripts/check-package.mjs",
     "check": "npm run build && npm run lint && npm run typecheck && npm test && npm run test:publint && npm run pack:check",
     "prepack": "npm run build",
     "prepublishOnly": "npm run check",

--- a/scripts/check-package.mjs
+++ b/scripts/check-package.mjs
@@ -1,0 +1,111 @@
+import { execFileSync } from 'node:child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+
+const root = process.cwd();
+const temporary = mkdtempSync(join(tmpdir(), 'askr-ui-pack-'));
+
+try {
+  const packed = JSON.parse(
+    execFileSync(
+      'npm',
+      ['pack', '--ignore-scripts', '--json', '--pack-destination', temporary],
+      { cwd: root, encoding: 'utf8' }
+    )
+  )[0];
+  const forbidden =
+    /(?:^|\/)(?:node_modules|\.cache|coverage)(?:\/|$)|\.tsbuildinfo$/;
+  const files = packed.files.map(({ path }) => path);
+  const rejected = files.filter((path) => forbidden.test(path));
+  if (rejected.length > 0) {
+    throw new Error(`Forbidden packed files:\n${rejected.join('\n')}`);
+  }
+
+  const packageJson = JSON.parse(
+    readFileSync(join(root, 'package.json'), 'utf8')
+  );
+  const targets = Object.values(packageJson.exports)
+    .flatMap((value) =>
+      typeof value === 'string' ? [value] : Object.values(value)
+    )
+    .filter(
+      (value) => typeof value === 'string' && value.startsWith('./dist/')
+    );
+  const missing = targets.filter(
+    (target) => !existsSync(resolve(root, target))
+  );
+  if (missing.length > 0) {
+    throw new Error(`Missing export targets:\n${missing.join('\n')}`);
+  }
+
+  const consumer = join(temporary, 'consumer');
+  mkdirSync(consumer);
+  const tarball = join(temporary, basename(packed.filename));
+  writeFileSync(
+    join(consumer, 'package.json'),
+    JSON.stringify({
+      private: true,
+      type: 'module',
+      dependencies: {
+        '@askrjs/askr': `file:${join(root, 'node_modules/@askrjs/askr')}`,
+        '@askrjs/ui': `file:${tarball}`,
+        typescript: `file:${join(root, 'node_modules/typescript')}`,
+      },
+    })
+  );
+  writeFileSync(
+    join(consumer, 'consumer.ts'),
+    `import { Button, HoverCard, ScrollArea } from '@askrjs/ui';
+import { DropdownItem } from '@askrjs/ui/dropdown';
+import { MenuItem } from '@askrjs/ui/menu';
+import { MenubarItem } from '@askrjs/ui/menubar';
+import { SelectItem } from '@askrjs/ui/select';
+void [Button, HoverCard, ScrollArea, DropdownItem, MenuItem, MenubarItem, SelectItem];
+`
+  );
+  writeFileSync(
+    join(consumer, 'consumer.mjs'),
+    `import { Button, HoverCard, ScrollArea } from '@askrjs/ui';
+import { DropdownItem } from '@askrjs/ui/dropdown';
+if (![Button, HoverCard, ScrollArea, DropdownItem].every(Boolean)) process.exit(1);
+`
+  );
+  writeFileSync(
+    join(consumer, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        target: 'ES2022',
+        skipLibCheck: false,
+        noEmit: true,
+      },
+      files: ['consumer.ts'],
+    })
+  );
+  execFileSync(
+    'npm',
+    ['install', '--ignore-scripts', '--no-audit', '--no-fund'],
+    {
+      cwd: consumer,
+      stdio: 'inherit',
+    }
+  );
+  execFileSync('node', ['consumer.mjs'], { cwd: consumer, stdio: 'inherit' });
+  execFileSync(
+    join(consumer, 'node_modules/.bin/tsc'),
+    ['-p', 'tsconfig.json'],
+    { cwd: consumer, stdio: 'inherit' }
+  );
+  console.log(`Validated ${files.length} packed files and isolated ESM/types.`);
+} finally {
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/src/components/_internal/composite.ts
+++ b/src/components/_internal/composite.ts
@@ -4,6 +4,7 @@ export type CompositeCollectionMetadata = {
   index: number;
   disabled: boolean;
   value?: string;
+  text?: string;
 };
 
 const compositeCollections = new Map<
@@ -52,7 +53,8 @@ function isSameCompositeMetadata(
   return (
     left.index === right.index &&
     left.disabled === right.disabled &&
-    left.value === right.value
+    left.value === right.value &&
+    left.text === right.text
   );
 }
 
@@ -95,7 +97,7 @@ export function registerCompositeNode(
     unregister,
   });
 
-  return metadataChanged;
+  return true;
 }
 
 export function firstEnabledCompositeIndex(

--- a/src/components/_internal/focus.ts
+++ b/src/components/_internal/focus.ts
@@ -1,15 +1,5 @@
 import type { Collection } from '@askrjs/askr/foundations/structures';
 
-const FOCUSABLE_SELECTOR = [
-  'a[href]',
-  'button:not([disabled])',
-  'input:not([disabled])',
-  'select:not([disabled])',
-  'textarea:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
-  '[contenteditable="true"]',
-].join(',');
-
 let keyboardModality = true;
 
 export function markKeyboardModality() {
@@ -24,15 +14,240 @@ export function isKeyboardModality() {
   return keyboardModality;
 }
 
-export function getFocusableElements(root: HTMLElement): HTMLElement[] {
-  return Array.from(
-    root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
-  ).filter(
-    (element) =>
-      !element.hasAttribute('disabled') &&
-      element.getAttribute('aria-disabled') !== 'true' &&
-      !element.hidden
+function flattenedElements(root: ParentNode): HTMLElement[] {
+  const result: HTMLElement[] = [];
+  const visit = (parent: ParentNode) => {
+    for (const child of parent.children) {
+      if (!(child instanceof HTMLElement)) {
+        continue;
+      }
+      result.push(child);
+
+      if (child instanceof HTMLSlotElement) {
+        const assigned = child.assignedElements({ flatten: true });
+        if (assigned.length > 0) {
+          for (const assignedElement of assigned) {
+            if (assignedElement instanceof HTMLElement) {
+              result.push(assignedElement);
+              visit(assignedElement);
+            }
+          }
+          continue;
+        }
+      }
+
+      if (child.shadowRoot) {
+        visit(child.shadowRoot);
+      } else {
+        visit(child);
+      }
+    }
+  };
+  visit(root);
+  return [...new Set(result)];
+}
+
+function isHidden(element: HTMLElement): boolean {
+  for (let current: HTMLElement | null = element; current;) {
+    if (current.hidden || current.hasAttribute('inert')) {
+      return true;
+    }
+    const style = getComputedStyle(current);
+    if (style.display === 'none' || style.visibility === 'hidden') {
+      return true;
+    }
+    const root = current.getRootNode();
+    current =
+      current.parentElement ??
+      (root instanceof ShadowRoot ? (root.host as HTMLElement) : null);
+  }
+  return false;
+}
+
+function isDisabledByFieldset(element: HTMLElement): boolean {
+  const fieldset = element.closest('fieldset[disabled]');
+  if (!fieldset) {
+    return false;
+  }
+  const firstLegend = Array.from(fieldset.children).find(
+    (child): child is HTMLLegendElement => child instanceof HTMLLegendElement
   );
+  return !firstLegend?.contains(element);
+}
+
+function isInsideClosedDetails(element: HTMLElement): boolean {
+  const details = element.closest('details:not([open])');
+  return Boolean(details && !element.closest('summary'));
+}
+
+function isNaturallyFocusable(element: HTMLElement): boolean {
+  if (
+    element instanceof HTMLButtonElement ||
+    element instanceof HTMLSelectElement ||
+    element instanceof HTMLTextAreaElement ||
+    element instanceof HTMLIFrameElement
+  ) {
+    return true;
+  }
+  if (element instanceof HTMLInputElement) {
+    return element.type !== 'hidden';
+  }
+  if (
+    (element instanceof HTMLAnchorElement ||
+      element instanceof HTMLAreaElement) &&
+    element.hasAttribute('href')
+  ) {
+    return true;
+  }
+  if (
+    element instanceof HTMLAudioElement ||
+    element instanceof HTMLVideoElement
+  ) {
+    return element.hasAttribute('controls');
+  }
+  return element.isContentEditable;
+}
+
+function isFocusable(element: HTMLElement): boolean {
+  return (
+    !element.hasAttribute('disabled') &&
+    !isDisabledByFieldset(element) &&
+    !isInsideClosedDetails(element) &&
+    !isHidden(element) &&
+    (element.hasAttribute('tabindex') || isNaturallyFocusable(element))
+  );
+}
+
+function filterRadioGroups(elements: HTMLElement[]): HTMLElement[] {
+  const selected = new Map<string, HTMLInputElement>();
+  for (const element of elements) {
+    if (!(element instanceof HTMLInputElement) || element.type !== 'radio') {
+      continue;
+    }
+    const formKey = element.form?.id ?? '';
+    const key = `${formKey}\0${element.name}`;
+    const current = selected.get(key);
+    if (!current || element.checked) {
+      selected.set(key, element);
+    }
+  }
+  return elements.filter(
+    (element) =>
+      !(element instanceof HTMLInputElement) ||
+      element.type !== 'radio' ||
+      !element.name ||
+      selected.get(`${element.form?.id ?? ''}\0${element.name}`) === element
+  );
+}
+
+export function getFocusableElements(root: HTMLElement): HTMLElement[] {
+  return flattenedElements(root).filter(isFocusable);
+}
+
+export function getTabbableElements(
+  root: ParentNode = document
+): HTMLElement[] {
+  const candidates = filterRadioGroups(
+    flattenedElements(root).filter(
+      (element) => isFocusable(element) && element.tabIndex >= 0
+    )
+  );
+  const positive = candidates
+    .filter((element) => element.tabIndex > 0)
+    .sort((left, right) => left.tabIndex - right.tabIndex);
+  return [
+    ...positive,
+    ...candidates.filter((element) => element.tabIndex === 0),
+  ];
+}
+
+export function dismissPopupWithTab(
+  event: KeyboardEvent,
+  trigger: HTMLElement | null,
+  excludedRoots: readonly HTMLElement[],
+  onDismiss: () => void
+): boolean {
+  if (event.key !== 'Tab') {
+    return false;
+  }
+
+  const candidates = getTabbableElements().filter(
+    (candidate) =>
+      !excludedRoots.some((excludedRoot) => excludedRoot.contains(candidate))
+  );
+  const triggerIndex = trigger ? candidates.indexOf(trigger) : -1;
+  const destination =
+    triggerIndex >= 0
+      ? candidates[triggerIndex + (event.shiftKey ? -1 : 1)]
+      : undefined;
+
+  if (destination) {
+    event.preventDefault();
+    event.stopPropagation();
+  }
+
+  onDismiss();
+
+  if (destination) {
+    queueMicrotask(() => {
+      queueMicrotask(() => {
+        if (destination.isConnected) {
+          destination.focus();
+        }
+      });
+    });
+  }
+
+  return true;
+}
+
+export function moveFocusOutsideCompositeWithTab(
+  event: KeyboardEvent,
+  composite: HTMLElement
+): boolean {
+  if (event.key !== 'Tab') {
+    return false;
+  }
+
+  const candidates = getTabbableElements();
+  const activeElement =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+  const activeIndex = activeElement ? candidates.indexOf(activeElement) : -1;
+
+  if (activeIndex < 0 || !composite.contains(activeElement)) {
+    return false;
+  }
+
+  const direction = event.shiftKey ? -1 : 1;
+  let destination: HTMLElement | undefined;
+
+  for (
+    let index = activeIndex + direction;
+    index >= 0 && index < candidates.length;
+    index += direction
+  ) {
+    const candidate = candidates[index];
+
+    if (candidate && !composite.contains(candidate)) {
+      destination = candidate;
+      break;
+    }
+  }
+
+  if (!destination) {
+    return false;
+  }
+
+  event.preventDefault();
+  event.stopPropagation();
+  queueMicrotask(() => {
+    if (destination?.isConnected) {
+      destination.focus();
+    }
+  });
+  return true;
 }
 
 export function focusFirstDescendant(root: HTMLElement): boolean {
@@ -71,4 +286,48 @@ export function focusSelectedCollectionItem<
 
   match.focus();
   return true;
+}
+
+export type PendingCollectionFocus = {
+  index: number | null;
+};
+
+export function focusCollectionItemWithRestore<
+  TMetadata extends { index: number },
+>(
+  pendingFocus: PendingCollectionFocus,
+  collection: Collection<HTMLElement, TMetadata>,
+  index: number,
+  resolveNode?: () => HTMLElement | null
+) {
+  const focusItem = () => {
+    const resolvedNode = resolveNode?.();
+
+    if (resolvedNode) {
+      resolvedNode.focus();
+      return true;
+    }
+
+    return focusSelectedCollectionItem(collection, index);
+  };
+
+  pendingFocus.index = index;
+  focusItem();
+  queueMicrotask(() => {
+    queueMicrotask(() => {
+      focusItem();
+      pendingFocus.index = null;
+    });
+  });
+}
+
+export function restorePendingCollectionItemFocus(
+  pendingFocus: PendingCollectionFocus,
+  index: number,
+  node: HTMLElement | null
+) {
+  if (node && pendingFocus.index === index) {
+    node.focus();
+    pendingFocus.index = null;
+  }
 }

--- a/src/components/_internal/press.ts
+++ b/src/components/_internal/press.ts
@@ -1,0 +1,48 @@
+import type { PressEvent } from './types';
+
+type PressHandler = (event: PressEvent) => void;
+
+function isPolyfilledKeyboardPress(event: PressEvent): boolean {
+  return event.defaultPrevented === true;
+}
+
+/**
+ * Runs a caller's cancelable press callback before a component's default
+ * action. The pressable foundation prevents native keyboard defaults before
+ * invoking non-native hosts, so expose a fresh cancellation state for that
+ * callback while preserving propagation on the original event.
+ */
+export function runCancelablePress(
+  event: PressEvent,
+  onPress: PressHandler | undefined,
+  defaultAction: () => void
+) {
+  if (!isPolyfilledKeyboardPress(event)) {
+    onPress?.(event);
+
+    if (!event.defaultPrevented) {
+      defaultAction();
+    }
+    return;
+  }
+
+  let callerPrevented = false;
+  const callerEvent: PressEvent = {
+    get defaultPrevented() {
+      return callerPrevented;
+    },
+    preventDefault: () => {
+      callerPrevented = true;
+      event.preventDefault?.();
+    },
+    stopPropagation: () => {
+      event.stopPropagation?.();
+    },
+  };
+
+  onPress?.(callerEvent);
+
+  if (!callerPrevented) {
+    defaultAction();
+  }
+}

--- a/src/components/_internal/typeahead.ts
+++ b/src/components/_internal/typeahead.ts
@@ -1,0 +1,240 @@
+export const TYPEAHEAD_RESET_MS = 500;
+
+export type TypeaheadItem = {
+  disabled: boolean;
+  text: string;
+};
+
+type TypeaheadEntry = {
+  cleanupSignal: AbortSignal | null;
+  currentMatchIndex: number | null;
+  search: string;
+  suppressSpaceKeyUp: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+type TypeaheadOptions = {
+  currentIndex: number;
+  items: readonly TypeaheadItem[];
+  onMatch: (index: number) => void;
+};
+
+const typeaheadEntries = new WeakMap<object, TypeaheadEntry>();
+
+function getTypeaheadEntry(identity: object): TypeaheadEntry {
+  const existing = typeaheadEntries.get(identity);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created: TypeaheadEntry = {
+    cleanupSignal: null,
+    currentMatchIndex: null,
+    search: '',
+    suppressSpaceKeyUp: false,
+    timer: null,
+  };
+  typeaheadEntries.set(identity, created);
+  return created;
+}
+
+function clearTypeaheadEntry(entry: TypeaheadEntry) {
+  if (entry.timer !== null) {
+    clearTimeout(entry.timer);
+    entry.timer = null;
+  }
+
+  entry.currentMatchIndex = null;
+  entry.search = '';
+}
+
+function normalizeTypeaheadText(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function resolvePrintableKey(event: KeyboardEvent): string | null {
+  if (
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.isComposing ||
+    Array.from(event.key).length !== 1
+  ) {
+    return null;
+  }
+
+  const target = event.target;
+
+  if (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLSelectElement ||
+    target instanceof HTMLTextAreaElement ||
+    (target instanceof HTMLElement && target.isContentEditable)
+  ) {
+    return null;
+  }
+
+  return event.key.toLowerCase();
+}
+
+function resolveSearchQuery(search: string): string {
+  const characters = Array.from(search);
+  const repeated =
+    characters.length > 1 &&
+    characters.every((character) => character === characters[0]);
+
+  return repeated ? (characters[0] ?? '') : search;
+}
+
+function findTypeaheadMatch(
+  items: readonly TypeaheadItem[],
+  query: string,
+  currentIndex: number
+): number {
+  if (items.length === 0 || query.length === 0) {
+    return -1;
+  }
+
+  const hasCurrentIndex = currentIndex >= 0 && currentIndex < items.length;
+  const excludeCurrentItem = query.length === 1 && hasCurrentIndex;
+  const startIndex = hasCurrentIndex
+    ? (currentIndex + (excludeCurrentItem ? 1 : 0)) % items.length
+    : 0;
+
+  for (let offset = 0; offset < items.length; offset += 1) {
+    const index = (startIndex + offset) % items.length;
+    const item = items[index];
+
+    if (
+      item &&
+      !item.disabled &&
+      normalizeTypeaheadText(item.text).startsWith(query)
+    ) {
+      return index;
+    }
+  }
+
+  return -1;
+}
+
+export function handleTypeaheadKeyDown(
+  identity: object,
+  event: KeyboardEvent,
+  options: TypeaheadOptions
+): boolean {
+  const entry = getTypeaheadEntry(identity);
+  const key = resolvePrintableKey(event);
+
+  if (event.key !== ' ') {
+    entry.suppressSpaceKeyUp = false;
+  }
+
+  if (key === null || event.defaultPrevented) {
+    const modifierOnly =
+      event.key === 'Alt' ||
+      event.key === 'AltGraph' ||
+      event.key === 'CapsLock' ||
+      event.key === 'Control' ||
+      event.key === 'Meta' ||
+      event.key === 'NumLock' ||
+      event.key === 'Shift';
+
+    if (
+      key === null &&
+      !modifierOnly &&
+      !event.altKey &&
+      !event.ctrlKey &&
+      !event.metaKey &&
+      !event.isComposing
+    ) {
+      clearTypeaheadEntry(entry);
+    }
+    return false;
+  }
+
+  if (key === ' ' && entry.search === '') {
+    entry.suppressSpaceKeyUp = false;
+    return false;
+  }
+
+  if (key === ' ' && entry.search !== '') {
+    entry.suppressSpaceKeyUp = true;
+  }
+
+  entry.search += key;
+  const query = normalizeTypeaheadText(resolveSearchQuery(entry.search));
+  const currentIndex = entry.currentMatchIndex ?? options.currentIndex;
+  const matchIndex = findTypeaheadMatch(options.items, query, currentIndex);
+
+  if (entry.timer !== null) {
+    clearTimeout(entry.timer);
+  }
+  entry.timer = setTimeout(() => {
+    clearTypeaheadEntry(entry);
+  }, TYPEAHEAD_RESET_MS);
+
+  event.preventDefault();
+
+  if (matchIndex >= 0) {
+    entry.currentMatchIndex = matchIndex;
+
+    if (matchIndex !== currentIndex) {
+      options.onMatch(matchIndex);
+    }
+  }
+
+  return true;
+}
+
+export function handleTypeaheadKeyUp(
+  identity: object,
+  event: KeyboardEvent
+): boolean {
+  const entry = typeaheadEntries.get(identity);
+
+  if (
+    event.key !== ' ' ||
+    !entry?.suppressSpaceKeyUp ||
+    event.defaultPrevented
+  ) {
+    return false;
+  }
+
+  entry.suppressSpaceKeyUp = false;
+  event.preventDefault();
+  return true;
+}
+
+export function registerTypeaheadCleanup(
+  identity: object,
+  signal: AbortSignal
+) {
+  const entry = getTypeaheadEntry(identity);
+
+  if (entry.cleanupSignal === signal) {
+    return;
+  }
+
+  entry.cleanupSignal = signal;
+  signal.addEventListener(
+    'abort',
+    () => {
+      if (entry.cleanupSignal !== signal) {
+        return;
+      }
+
+      clearTypeaheadEntry(entry);
+      typeaheadEntries.delete(identity);
+    },
+    { once: true }
+  );
+}
+
+export function resetTypeahead(identity: object) {
+  const entry = typeaheadEntries.get(identity);
+
+  if (entry) {
+    clearTypeaheadEntry(entry);
+  }
+}

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -3,6 +3,7 @@ import { Presence, Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { focusSelectedCollectionItem } from '../_internal/focus';
+import { runCancelablePress } from '../_internal/press';
 import {
   disabledIndexes,
   firstEnabledCompositeIndex,
@@ -282,9 +283,7 @@ export function AccordionTrigger(
   const interactionProps = pressable({
     disabled: isDisabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setValue(
           toggleDisclosureValue(
             root.type,
@@ -294,13 +293,14 @@ export function AccordionTrigger(
           )
         );
         root.setCurrentIndex(item.itemIndex);
-      }
+      });
     },
     isNativeButton: !asChild,
   });
+  const itemFocusProps = nav.item(item.itemIndex);
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(item.itemIndex),
+    ...itemFocusProps,
     ref: composeRefs(
       ref as
         | ((value: HTMLElement | null) => void)
@@ -321,6 +321,7 @@ export function AccordionTrigger(
     'aria-expanded': open ? 'true' : 'false',
     'data-state': open ? 'open' : 'closed',
     'data-disabled': isDisabled ? 'true' : undefined,
+    tabIndex: isDisabled ? -1 : 0,
   });
 
   if (asChild) {

--- a/src/components/checkbox/checkbox.tsx
+++ b/src/components/checkbox/checkbox.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
-import { controllableState } from '@askrjs/askr/foundations/state';
+import { state } from '@askrjs/askr';
+import { runCancelablePress } from '../_internal/press';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import type {
@@ -66,22 +67,21 @@ export function Checkbox(props: CheckboxInputProps | CheckboxAsChildProps) {
     ...rest
   } = props;
 
-  const checkedState = controllableState({
-    value: checked,
-    defaultValue: defaultChecked,
-    onChange: onCheckedChange,
-  });
   const isControlled = checked !== undefined;
-  const currentChecked = checkedState();
+  const internalChecked = state(defaultChecked);
+  const internalCheckedValue = internalChecked();
+  const currentChecked = isControlled ? checked : internalCheckedValue;
+  const setChecked = (next: boolean) => {
+    if (!isControlled) {
+      internalChecked.set(next);
+    }
+    onCheckedChange?.(next);
+  };
 
   const toggleChecked = (event: PressEvent) => {
-    onPress?.(event);
-
-    if (event.defaultPrevented) {
-      return;
-    }
-
-    checkedState.set(!checkedState());
+    runCancelablePress(event, onPress, () => {
+      setChecked(!currentChecked);
+    });
   };
 
   const ariaChecked = indeterminate
@@ -125,12 +125,12 @@ export function Checkbox(props: CheckboxInputProps | CheckboxAsChildProps) {
       toggleChecked(e as PressEvent);
 
       if (isControlled) {
-        (e.currentTarget as HTMLInputElement).checked = checkedState();
+        (e.currentTarget as HTMLInputElement).checked = currentChecked;
       }
     },
     onChange: isControlled
       ? (e: Event) => {
-          (e.currentTarget as HTMLInputElement).checked = checkedState();
+          (e.currentTarget as HTMLInputElement).checked = currentChecked;
         }
       : undefined,
     'aria-checked': indeterminate ? undefined : ariaChecked,

--- a/src/components/collapsible/collapsible.tsx
+++ b/src/components/collapsible/collapsible.tsx
@@ -129,23 +129,6 @@ export function CollapsibleTrigger(
     'aria-controls': root.contentId,
     'data-state': root.open ? 'open' : 'closed',
     'data-disabled': root.disabled ? 'true' : undefined,
-    onKeyDown: !asChild
-      ? (event: KeyboardEvent) => {
-          if (event.key === ' ') {
-            event.preventDefault();
-          }
-          if (event.key === 'Enter') {
-            toggleOpen(event);
-          }
-        }
-      : undefined,
-    onKeyUp: !asChild
-      ? (event: KeyboardEvent) => {
-          if (event.key === ' ') {
-            toggleOpen(event);
-          }
-        }
-      : undefined,
   });
 
   if (asChild) {

--- a/src/components/dialog/dialog-close.tsx
+++ b/src/components/dialog/dialog-close.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
+import { runCancelablePress } from '../_internal/press';
 import { readDialogRootContext } from './dialog.shared';
 import type { DialogCloseAsChildProps, DialogCloseProps } from './dialog.types';
 
@@ -20,11 +21,9 @@ export function DialogClose(props: DialogCloseProps | DialogCloseAsChildProps) {
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(false);
-      }
+      });
     },
     isNativeButton: !asChild,
   });

--- a/src/components/dialog/dialog-trigger.tsx
+++ b/src/components/dialog/dialog-trigger.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
+import { runCancelablePress } from '../_internal/press';
 import { readDialogRootContext } from './dialog.shared';
 import type {
   DialogTriggerAsChildProps,
@@ -25,11 +26,9 @@ export function DialogTrigger(
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(!root.open);
-      }
+      });
     },
     isNativeButton: !asChild,
   });

--- a/src/components/dropdown/dropdown-content.tsx
+++ b/src/components/dropdown/dropdown-content.tsx
@@ -3,7 +3,10 @@ import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { DismissableLayer } from '../dismissable-layer';
 import { FocusScope } from '../focus-scope';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  dismissPopupWithTab,
+  focusSelectedCollectionItem,
+} from '../_internal/focus';
 import { getMenuCollection } from '../_internal/menu';
 import {
   clearOverlayPosition,
@@ -55,7 +58,7 @@ export function DropdownContent(
       }
 
       root.setCurrentIndex(index);
-      focusSelectedCollectionItem(collection, index);
+      root.focusItem(index);
     },
   });
   const setNode = (node: HTMLElement | null) => {
@@ -87,7 +90,6 @@ export function DropdownContent(
       )
     : setNode;
   const finalProps = mergeProps(rest, {
-    ...nav.container,
     ref: refHandler,
     id: root.contentId,
     role: 'menu',
@@ -96,6 +98,26 @@ export function DropdownContent(
     'data-side': side,
     'data-align': align,
     'data-side-offset': String(sideOffset),
+    onKeyDown: (event: KeyboardEvent) => {
+      if (root.handleTypeaheadKeyDown(event)) {
+        return;
+      }
+
+      nav.container.onKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      dismissPopupWithTab(
+        event,
+        overlayNodes.trigger,
+        overlayNodes.content ? [overlayNodes.content] : [],
+        () => {
+          root.setOpen(false);
+        }
+      );
+    },
   });
   const contentNode = asChild ? (
     <Slot asChild {...finalProps} children={children} />

--- a/src/components/dropdown/dropdown-item.tsx
+++ b/src/components/dropdown/dropdown-item.tsx
@@ -1,13 +1,13 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
 import {
   getMenuCollection,
   registerCollectionNode,
   resolveMenuItemText,
 } from '../_internal/menu';
 import { resolvePartId } from '../_internal/id';
+import { runCancelablePress } from '../_internal/press';
 import {
   readDropdownRenderContext,
   readDropdownRootContext,
@@ -31,6 +31,7 @@ export function DropdownItem(
     value,
     onSelect,
     ref,
+    textValue,
     type: typeProp,
     variant,
     ...rest
@@ -41,7 +42,7 @@ export function DropdownItem(
   const stableItemKey =
     typeof value === 'string' && value.length > 0 ? value : String(itemIndex);
   const itemId = resolvePartId(root.dropdownId, `item-${stableItemKey}`);
-  const itemText = resolveMenuItemText(children);
+  const itemText = resolveMenuItemText(children, textValue);
   const { items, currentIndex, disabledIndexes } = root.resolvedState;
   const hasEnabledItems = items.some(
     (_item, index) => !disabledIndexes.includes(index)
@@ -59,20 +60,33 @@ export function DropdownItem(
       }
 
       root.setCurrentIndex(index);
-      focusSelectedCollectionItem(collection, index);
+      root.focusItem(index);
     },
   });
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onSelect?.(event);
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onSelect, () => {
         root.setCurrentIndex(itemIndex);
         root.setOpen(false);
-      }
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!disabled && root.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (root.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
   const setNode = (node: HTMLElement | null) => {
     registerCollectionNode(itemId, collection, node, {
       index: itemIndex,
@@ -80,6 +94,7 @@ export function DropdownItem(
       value: stableItemKey,
       text: itemText,
     });
+    root.restoreItemFocus(itemIndex, node);
   };
   const refHandler = ref
     ? composeRefs(
@@ -93,11 +108,14 @@ export function DropdownItem(
     : setNode;
   const finalProps = mergeProps(rest, {
     ...interactionProps,
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
     ...nav.item(itemIndex),
     ...(disabled ? { tabIndex: -1 } : {}),
     ref: refHandler,
     id: itemId,
     role: 'menuitem',
+    disabled: disabled && !asChild ? true : undefined,
     'aria-disabled': disabled ? 'true' : undefined,
     'data-slot': 'dropdown-item',
     'data-disabled': disabled ? 'true' : undefined,

--- a/src/components/dropdown/dropdown-root.tsx
+++ b/src/components/dropdown/dropdown-root.tsx
@@ -1,4 +1,4 @@
-import { cspNonce, state } from '@askrjs/askr';
+import { cspNonce, getSignal, state } from '@askrjs/askr';
 import { controllableState } from '@askrjs/askr/foundations/state';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
 import {
@@ -6,6 +6,18 @@ import {
   createOverlayIdentity,
   getPersistentPortal,
 } from '../_internal/overlay';
+import {
+  focusCollectionItemWithRestore,
+  restorePendingCollectionItemFocus,
+  type PendingCollectionFocus,
+} from '../_internal/focus';
+import { getMenuCollection } from '../_internal/menu';
+import {
+  handleTypeaheadKeyDown,
+  handleTypeaheadKeyUp,
+  registerTypeaheadCleanup,
+  resetTypeahead,
+} from '../_internal/typeahead';
 import {
   createDropdownRenderContext,
   DropdownRenderContext,
@@ -25,21 +37,71 @@ export function Dropdown(props: DropdownProps) {
   const dropdownId = resolveCompoundId('dropdown', id, children);
   const overlayIdentity = state(createOverlayIdentity())();
   captureOverlayNonce(overlayIdentity, cspNonce());
+  registerTypeaheadCleanup(overlayIdentity, getSignal());
   const currentIndexState = state(0);
+  const pendingFocus = state<PendingCollectionFocus>({ index: null })();
+  const setCurrentIndex = (index: number) => {
+    if (currentIndexState() !== index) {
+      currentIndexState.set(index);
+    }
+  };
   const rootContextBase = {
     dropdownId,
     overlayIdentity,
     currentIndexCandidate: currentIndexState(),
   };
   const resolvedState = resolveDropdownState(rootContextBase);
+  const collection = getMenuCollection(dropdownId);
+  const focusItem = (index: number) => {
+    const itemValue = resolveDropdownState({
+      dropdownId,
+      currentIndexCandidate: currentIndexState(),
+    }).items[index]?.value;
+    focusCollectionItemWithRestore(
+      pendingFocus,
+      collection,
+      index,
+      itemValue === undefined
+        ? undefined
+        : () =>
+            document.getElementById(
+              resolvePartId(dropdownId, `item-${itemValue}`)
+            )
+    );
+  };
+  const setOpen = (nextOpen: boolean) => {
+    resetTypeahead(overlayIdentity);
+    openState.set(nextOpen);
+  };
   const rootContext: DropdownRootContextValue = {
     ...rootContextBase,
     open: openState(),
-    setOpen: openState.set,
+    setOpen,
     contentId: resolvePartId(dropdownId, 'content'),
     portal: getPersistentPortal(overlayIdentity),
-    setCurrentIndex: currentIndexState.set,
+    setCurrentIndex,
+    focusItem,
+    restoreItemFocus: (index, node) => {
+      restorePendingCollectionItemFocus(pendingFocus, index, node);
+    },
     resolvedState,
+    handleTypeaheadKeyDown: (event) => {
+      const liveState = resolveDropdownState({
+        dropdownId,
+        currentIndexCandidate: currentIndexState(),
+      });
+
+      return handleTypeaheadKeyDown(overlayIdentity, event, {
+        currentIndex: liveState.currentIndex,
+        items: liveState.items,
+        onMatch: (index) => {
+          setCurrentIndex(index);
+          focusItem(index);
+        },
+      });
+    },
+    handleTypeaheadKeyUp: (event) =>
+      handleTypeaheadKeyUp(overlayIdentity, event),
   };
   const runtimeRenderContext = createDropdownRenderContext();
   const PortalHost = rootContext.portal;

--- a/src/components/dropdown/dropdown-trigger.tsx
+++ b/src/components/dropdown/dropdown-trigger.tsx
@@ -2,6 +2,7 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import { getOverlayNodes } from '../_internal/overlay';
+import { runCancelablePress } from '../_internal/press';
 import { readDropdownRootContext } from './dropdown.shared';
 import type {
   DropdownPortalProps,
@@ -34,13 +35,24 @@ export function DropdownTrigger(
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(!root.open);
-      }
+      });
     },
     isNativeButton: !asChild,
   });
+  const handleKeyDown = (event: KeyboardEvent) => {
+    interactionProps.onKeyDown?.(event);
+
+    if (
+      !event.defaultPrevented &&
+      !disabled &&
+      (event.key === 'ArrowDown' || event.key === 'ArrowUp')
+    ) {
+      event.preventDefault();
+      root.setOpen(true);
+    }
+  };
   const setNode = (node: HTMLElement | null) => {
     overlayNodes.trigger = node;
   };
@@ -56,6 +68,7 @@ export function DropdownTrigger(
     : setNode;
   const finalProps = mergeProps(rest, {
     ...interactionProps,
+    onKeyDown: handleKeyDown,
     ref: refHandler,
     'aria-haspopup': 'menu',
     'aria-expanded': root.open ? 'true' : 'false',

--- a/src/components/dropdown/dropdown.shared.ts
+++ b/src/components/dropdown/dropdown.shared.ts
@@ -21,7 +21,11 @@ export type DropdownRootContextValue = {
   portal: OverlayPortal;
   currentIndexCandidate: number;
   setCurrentIndex: (index: number) => void;
+  focusItem: (index: number) => void;
+  restoreItemFocus: (index: number, node: HTMLElement | null) => void;
   resolvedState: DropdownResolvedState;
+  handleTypeaheadKeyDown: (event: KeyboardEvent) => boolean;
+  handleTypeaheadKeyUp: (event: KeyboardEvent) => boolean;
 };
 
 export type DropdownRenderContextValue = {

--- a/src/components/dropdown/dropdown.types.ts
+++ b/src/components/dropdown/dropdown.types.ts
@@ -57,6 +57,8 @@ export type DropdownItemOwnProps = {
   value?: string;
   variant?: DropdownItemVariant;
   onSelect?: (event: PressEvent) => void;
+  /** Text used for typeahead when rendered children are not plain text. */
+  textValue?: string;
 };
 
 export type DropdownItemVariant = 'default' | 'destructive';

--- a/src/components/hover-card/hover-card-content.tsx
+++ b/src/components/hover-card/hover-card-content.tsx
@@ -1,7 +1,7 @@
 import { Presence, Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { DismissableLayer } from '../dismissable-layer';
-import { FocusScope } from '../focus-scope';
+import { dismissPopupWithTab, getFocusableElements } from '../_internal/focus';
 import {
   readHoverCardRootContext,
   resolveHoverCardPositionOptions,
@@ -83,6 +83,63 @@ export function HoverCardContent(
     onMouseOut: () => {
       root.scheduleClose();
     },
+    onFocusIn: () => {
+      root.cancelClose();
+    },
+    onFocusOut: (event: FocusEvent) => {
+      const content = root.getContentNode();
+      const next =
+        event.relatedTarget instanceof Node ? event.relatedTarget : null;
+      if (!content || !next || !content.contains(next)) {
+        root.scheduleClose();
+      }
+    },
+    onKeyDown: (event: KeyboardEvent) => {
+      const content = root.getContentNode();
+      const trigger = root.getTriggerNode();
+      if (!content) {
+        return;
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        root.requestTriggerFocus();
+        root.setOpen(false);
+        queueMicrotask(() => {
+          queueMicrotask(() => {
+            (
+              document.getElementById(root.triggerId) ?? root.getTriggerNode()
+            )?.focus();
+          });
+        });
+        return;
+      }
+      if (event.key !== 'Tab') {
+        return;
+      }
+      const focusable = getFocusableElements(content);
+      const active =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : null;
+      if (event.shiftKey && active === focusable[0] && trigger) {
+        event.preventDefault();
+        root.requestTriggerFocus();
+        root.setOpen(false);
+        queueMicrotask(() => {
+          queueMicrotask(() => {
+            (
+              document.getElementById(root.triggerId) ?? root.getTriggerNode()
+            )?.focus();
+          });
+        });
+        return;
+      }
+      if (!event.shiftKey && active === focusable[focusable.length - 1]) {
+        dismissPopupWithTab(event, trigger, [content], () =>
+          root.setOpen(false)
+        );
+      }
+    },
   });
   const contentNode = asChild ? (
     <Slot asChild {...finalProps} children={children} />
@@ -94,11 +151,12 @@ export function HoverCardContent(
 
   return (
     <Presence present={forceMount || root.open}>
-      <FocusScope restoreFocus>
-        <DismissableLayer onDismiss={() => root.setOpen(false)}>
-          {contentNode}
-        </DismissableLayer>
-      </FocusScope>
+      <DismissableLayer
+        onEscapeKeyDown={() => root.requestTriggerFocus()}
+        onDismiss={() => root.setOpen(false)}
+      >
+        {contentNode}
+      </DismissableLayer>
     </Presence>
   );
 }

--- a/src/components/hover-card/hover-card-trigger.tsx
+++ b/src/components/hover-card/hover-card-trigger.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { hoverable, pressable } from '@askrjs/askr/foundations/interactions';
+import { focusFirstDescendant } from '../_internal/focus';
 import { readHoverCardRootContext } from './hover-card.shared';
 import type {
   HoverCardTriggerAsChildProps,
@@ -62,8 +63,22 @@ export function HoverCardTrigger(
       root.cancelClose();
       root.setOpen(true);
     },
+    onFocusIn: () => {
+      root.cancelClose();
+      root.setOpen(true);
+    },
     onBlur: () => {
       root.scheduleClose();
+    },
+    onKeyDown: (event: KeyboardEvent) => {
+      if (event.key !== 'Tab' || event.shiftKey || !root.open) {
+        return;
+      }
+      const content = root.getContentNode();
+      if (content && focusFirstDescendant(content)) {
+        event.preventDefault();
+        root.cancelClose();
+      }
     },
   });
 

--- a/src/components/hover-card/hover-card.shared.ts
+++ b/src/components/hover-card/hover-card.shared.ts
@@ -27,6 +27,9 @@ export type HoverCardRootContextValue = {
   registerContentPosition: (position: HoverCardPositionOptions) => void;
   setTriggerNode: (node: HTMLElement | null) => void;
   setContentNode: (node: HTMLElement | null) => void;
+  getTriggerNode: () => HTMLElement | null;
+  getContentNode: () => HTMLElement | null;
+  requestTriggerFocus: () => void;
   syncPosition: () => void;
   clearPosition: () => void;
 };

--- a/src/components/hover-card/hover-card.tsx
+++ b/src/components/hover-card/hover-card.tsx
@@ -1,5 +1,5 @@
 import { controllableState } from '@askrjs/askr/foundations/state';
-import { cspNonce, state } from '@askrjs/askr';
+import { cspNonce, getSignal, state } from '@askrjs/askr';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
 import {
   captureOverlayNonce,
@@ -38,6 +38,10 @@ export function HoverCard(props: HoverCardProps) {
   });
   const hoverCardId = resolveCompoundId('hover-card', id, children);
   const overlayIdentity = state(createOverlayIdentity())();
+  const focusEntry = state({
+    restoreTrigger: false,
+    restoreFrame: null as number | null,
+  })();
   captureOverlayNonce(overlayIdentity, cspNonce());
   const triggerId = resolvePartId(hoverCardId, 'trigger');
   const contentId = resolvePartId(hoverCardId, 'content');
@@ -59,6 +63,18 @@ export function HoverCard(props: HoverCardProps) {
       closeTimer = undefined;
     }
   };
+  const cleanupSignal = getSignal();
+  cleanupSignal.addEventListener(
+    'abort',
+    () => {
+      clearTimers();
+      clearOverlayPosition(overlayIdentity);
+      if (focusEntry.restoreFrame !== null) {
+        cancelAnimationFrame(focusEntry.restoreFrame);
+      }
+    },
+    { once: true }
+  );
 
   const rootContext: HoverCardRootContextValue = {
     hoverCardId,
@@ -111,9 +127,31 @@ export function HoverCard(props: HoverCardProps) {
     },
     setTriggerNode: (node: HTMLElement | null) => {
       overlayNodes.trigger = node;
+      if (node && focusEntry.restoreTrigger) {
+        focusEntry.restoreTrigger = false;
+        node.focus();
+      }
     },
     setContentNode: (node: HTMLElement | null) => {
       overlayNodes.content = node;
+    },
+    getTriggerNode: () => overlayNodes.trigger,
+    getContentNode: () => overlayNodes.content,
+    requestTriggerFocus: () => {
+      focusEntry.restoreTrigger = true;
+      overlayNodes.trigger?.focus();
+      if (focusEntry.restoreFrame !== null) {
+        cancelAnimationFrame(focusEntry.restoreFrame);
+      }
+      focusEntry.restoreFrame = requestAnimationFrame(() => {
+        focusEntry.restoreFrame = null;
+        const trigger =
+          document.getElementById(triggerId) ?? overlayNodes.trigger;
+        if (trigger) {
+          focusEntry.restoreTrigger = false;
+          trigger.focus();
+        }
+      });
     },
     syncPosition: () => {
       if (overlayNodes.content) {

--- a/src/components/menu/menu-content.tsx
+++ b/src/components/menu/menu-content.tsx
@@ -1,5 +1,6 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
+import { moveFocusOutsideCompositeWithTab } from '../_internal/focus';
 import { readMenuRootContext } from './menu.shared';
 import type { MenuContentAsChildProps, MenuContentProps } from './menu.types';
 
@@ -9,13 +10,26 @@ export function MenuContent(props: MenuContentProps | MenuContentAsChildProps) {
   const { asChild, children, ref, ...rest } = props;
   const root = readMenuRootContext();
   const finalProps = mergeProps(rest, {
-    ...root.navigation.container,
     ref,
     'data-slot': 'menu-content',
     'data-orientation': root.orientation,
     role: 'menu',
     'aria-orientation':
       root.orientation === 'both' ? undefined : root.orientation,
+    onKeyDown: (event: KeyboardEvent) => {
+      if (root.handleTypeaheadKeyDown(event)) {
+        return;
+      }
+
+      root.navigation.container.onKeyDown?.(event);
+
+      if (!event.defaultPrevented) {
+        moveFocusOutsideCompositeWithTab(
+          event,
+          event.currentTarget as HTMLElement
+        );
+      }
+    },
   });
 
   if (asChild) {

--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -7,6 +7,7 @@ import {
   resolveMenuItemText,
 } from '../_internal/menu';
 import { resolvePartId } from '../_internal/id';
+import { runCancelablePress } from '../_internal/press';
 import { readMenuRenderContext, readMenuRootContext } from './menu.shared';
 import type { MenuItemAsChildProps, MenuItemProps } from './menu.types';
 
@@ -19,6 +20,7 @@ export function MenuItem(props: MenuItemProps | MenuItemAsChildProps) {
     disabled = false,
     onSelect,
     ref,
+    textValue,
     type: typeProp,
     ...rest
   } = props;
@@ -26,21 +28,37 @@ export function MenuItem(props: MenuItemProps | MenuItemAsChildProps) {
   const renderContext = readMenuRenderContext();
   const itemIndex = renderContext.claimItemIndex();
   const itemId = resolvePartId(root.menuId, `item-${itemIndex}`);
-  const itemText = resolveMenuItemText(children);
+  const itemText = resolveMenuItemText(children, textValue);
   const collection = getMenuCollection(root.menuId);
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onSelect?.(event);
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onSelect, () => {
         root.setCurrentIndex(itemIndex);
-      }
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
+  const itemFocusProps = root.navigation.item(itemIndex);
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!disabled && root.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (root.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...root.navigation.item(itemIndex),
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
+    ...itemFocusProps,
     ref: composeRefs(
       ref as
         | ((value: HTMLElement | null) => void)
@@ -57,9 +75,11 @@ export function MenuItem(props: MenuItemProps | MenuItemAsChildProps) {
     ),
     id: itemId,
     role: 'menuitem',
+    disabled: disabled && !asChild ? true : undefined,
     'aria-disabled': disabled ? 'true' : undefined,
     'data-slot': 'menu-item',
     'data-disabled': disabled ? 'true' : undefined,
+    tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
   });
 
   if (asChild) {

--- a/src/components/menu/menu-root.tsx
+++ b/src/components/menu/menu-root.tsx
@@ -1,8 +1,13 @@
-import { state } from '@askrjs/askr';
+import { getSignal, state } from '@askrjs/askr';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { resolveCompoundId } from '../_internal/id';
 import { focusSelectedCollectionItem } from '../_internal/focus';
-import { getMenuCollection } from '../_internal/menu';
+import { getMenuCollection, getMenuCollectionItems } from '../_internal/menu';
+import {
+  handleTypeaheadKeyDown,
+  handleTypeaheadKeyUp,
+  registerTypeaheadCleanup,
+} from '../_internal/typeahead';
 import {
   createMenuRenderContext,
   MenuRenderContext,
@@ -16,6 +21,13 @@ export function Menu(props: MenuProps) {
   const { children, id, orientation = 'vertical', loop = true } = props;
   const menuId = resolveCompoundId('menu', id, children);
   const currentIndexState = state(0);
+  const typeaheadIdentity = state<object>({})();
+  registerTypeaheadCleanup(typeaheadIdentity, getSignal());
+  const setCurrentIndex = (index: number) => {
+    if (currentIndexState() !== index) {
+      currentIndexState.set(index);
+    }
+  };
   const rootContextBase = {
     menuId,
     currentIndexCandidate: currentIndexState(),
@@ -29,7 +41,7 @@ export function Menu(props: MenuProps) {
     loop,
     isDisabled: (index) => resolvedState.disabledIndexes.includes(index),
     onNavigate: (index) => {
-      currentIndexState.set(index);
+      setCurrentIndex(index);
       focusSelectedCollectionItem(collection, index);
     },
   });
@@ -37,9 +49,23 @@ export function Menu(props: MenuProps) {
     ...rootContextBase,
     orientation,
     loop,
-    setCurrentIndex: currentIndexState.set,
+    setCurrentIndex,
     resolvedState,
     navigation,
+    handleTypeaheadKeyDown: (event) => {
+      const items = getMenuCollectionItems(collection);
+
+      return handleTypeaheadKeyDown(typeaheadIdentity, event, {
+        currentIndex: currentIndexState(),
+        items,
+        onMatch: (index) => {
+          setCurrentIndex(index);
+          focusSelectedCollectionItem(collection, index);
+        },
+      });
+    },
+    handleTypeaheadKeyUp: (event) =>
+      handleTypeaheadKeyUp(typeaheadIdentity, event),
   };
   const renderContext = createMenuRenderContext();
 

--- a/src/components/menu/menu.shared.ts
+++ b/src/components/menu/menu.shared.ts
@@ -21,6 +21,8 @@ export type MenuRootContextValue = {
   setCurrentIndex: (index: number) => void;
   resolvedState: MenuResolvedState;
   navigation: RovingFocusResult;
+  handleTypeaheadKeyDown: (event: KeyboardEvent) => boolean;
+  handleTypeaheadKeyUp: (event: KeyboardEvent) => boolean;
 };
 
 export type MenuRenderContextValue = {

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -24,6 +24,8 @@ export type MenuItemOwnProps = {
   children?: unknown;
   disabled?: boolean;
   onSelect?: (event: PressEvent) => void;
+  /** Text used for typeahead when rendered children are not plain text. */
+  textValue?: string;
 };
 
 export type MenuItemProps = Omit<

--- a/src/components/menubar/menubar-content.tsx
+++ b/src/components/menubar/menubar-content.tsx
@@ -1,12 +1,23 @@
-import { state } from '@askrjs/askr';
+import { getSignal, state } from '@askrjs/askr';
 import { Presence, Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { DismissableLayer } from '../dismissable-layer';
 import { FocusScope } from '../focus-scope';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  dismissPopupWithTab,
+  focusCollectionItemWithRestore,
+  focusSelectedCollectionItem,
+  restorePendingCollectionItemFocus,
+  type PendingCollectionFocus,
+} from '../_internal/focus';
 import { pathIsOpen } from '../_internal/hierarchical-menu';
 import { getCompositeCollection } from '../_internal/composite';
+import {
+  handleTypeaheadKeyDown,
+  handleTypeaheadKeyUp,
+  registerTypeaheadCleanup,
+} from '../_internal/typeahead';
 import {
   clearOverlayPosition,
   getOverlayNodes,
@@ -55,6 +66,30 @@ function renderMenubarSurfaceContent(
     ...rest
   } = props;
   const currentIndexState = state(0);
+  const typeaheadIdentity = state<object>({})();
+  const pendingFocus = state<PendingCollectionFocus>({ index: null })();
+  registerTypeaheadCleanup(typeaheadIdentity, getSignal());
+  const setCurrentIndex = (index: number) => {
+    if (currentIndexState() !== index) {
+      currentIndexState.set(index);
+    }
+  };
+  const collection = getCompositeCollection(owner.contentId);
+  const focusItem = (index: number) => {
+    focusCollectionItemWithRestore(pendingFocus, collection, index);
+  };
+  function handleContentTypeaheadKeyDown(event: KeyboardEvent) {
+    const liveState = resolveMenubarContentState(contentContext);
+
+    return handleTypeaheadKeyDown(typeaheadIdentity, event, {
+      currentIndex: liveState.currentIndex,
+      items: liveState.items,
+      onMatch: (index) => {
+        contentContext.setCurrentIndex(index);
+        contentContext.focusItem(index);
+      },
+    });
+  }
   const contentContext: MenubarContentContextValue = {
     contentId: owner.contentId,
     triggerId: owner.triggerId,
@@ -62,7 +97,14 @@ function renderMenubarSurfaceContent(
     overlayIdentity: owner.overlayIdentity,
     path: owner.path,
     currentIndexCandidate: currentIndexState(),
-    setCurrentIndex: currentIndexState.set,
+    setCurrentIndex,
+    focusItem,
+    restoreItemFocus: (index, node) => {
+      restorePendingCollectionItemFocus(pendingFocus, index, node);
+    },
+    handleTypeaheadKeyDown: handleContentTypeaheadKeyDown,
+    handleTypeaheadKeyUp: (event) =>
+      handleTypeaheadKeyUp(typeaheadIdentity, event),
   };
   const runtimeRenderContext = createMenubarContentRenderContext();
 
@@ -76,7 +118,6 @@ function renderMenubarSurfaceContent(
     resolveMenubarContentState(contentContext);
   const open = pathIsOpen(root.openPath, contentContext.path);
   const overlayNodes = getOverlayNodes(contentContext.overlayIdentity);
-  const collection = getCompositeCollection(contentContext.contentId);
   const nav = rovingFocus({
     currentIndex,
     itemCount: Math.max(items.length, 1),
@@ -85,7 +126,7 @@ function renderMenubarSurfaceContent(
     isDisabled: (index) => disabledItemIndexes.includes(index),
     onNavigate: (index) => {
       contentContext.setCurrentIndex(index);
-      focusSelectedCollectionItem(collection, index);
+      contentContext.focusItem(index);
     },
   });
   const setNode = (node: HTMLElement | null) => {
@@ -167,7 +208,6 @@ function renderMenubarSurfaceContent(
       )
     : setNode;
   const finalProps = mergeProps(rest, {
-    ...nav.container,
     ref: refHandler,
     id: contentContext.contentId,
     role: 'menu',
@@ -179,6 +219,16 @@ function renderMenubarSurfaceContent(
     'data-side-offset': String(sideOffset),
     'data-askr-overlay-id': open ? contentContext.overlayId : undefined,
     onKeyDown: (event: KeyboardEvent) => {
+      if (contentContext.handleTypeaheadKeyDown(event)) {
+        return;
+      }
+
+      nav.container.onKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
       if (event.key === 'Escape') {
         event.preventDefault();
         root.setOpenPath(contentContext.path.slice(0, -1));
@@ -188,6 +238,24 @@ function renderMenubarSurfaceContent(
         event.preventDefault();
         root.setOpenPath(contentContext.path.slice(0, -1));
       }
+
+      const rootTrigger = getCompositeCollection(root.menubarId)
+        .items()
+        .find((item) => item.metadata.value === contentContext.path[0])?.node;
+
+      dismissPopupWithTab(
+        event,
+        rootTrigger ?? null,
+        Array.from(
+          document.querySelectorAll<HTMLElement>(
+            '[data-slot="menubar-content"]'
+          )
+        ),
+        () => {
+          root.setOpenPath([]);
+          queueMicrotask(root.syncPortals);
+        }
+      );
     },
   });
   return (

--- a/src/components/menubar/menubar-item.tsx
+++ b/src/components/menubar/menubar-item.tsx
@@ -5,7 +5,9 @@ import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { focusSelectedCollectionItem } from '../_internal/focus';
 import { resolvePartId } from '../_internal/id';
 import { pathIsOpen } from '../_internal/hierarchical-menu';
+import { resolveMenuItemText } from '../_internal/menu';
 import { getOverlayNodes } from '../_internal/overlay';
+import { runCancelablePress } from '../_internal/press';
 import {
   getCompositeCollection,
   registerCompositeNode,
@@ -46,6 +48,7 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
     disabled = false,
     onPress,
     ref,
+    textValue,
     type: typeProp,
     ...rest
   } = props;
@@ -60,6 +63,7 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
   }
 
   const surfaceId = resolvePartId(content.contentId, `item-${surfaceIndex}`);
+  const itemText = resolveMenuItemText(children, textValue);
   const { items, currentIndex, disabledItemIndexes } =
     resolveMenubarContentState(content);
   const collection = getCompositeCollection(content.contentId);
@@ -77,20 +81,35 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpenPath([]);
         scheduleMenubarPortalSync(root);
-      }
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
+  const itemFocusProps = nav.item(surfaceIndex);
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!disabled && content.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (content.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
   const setNode = (node: HTMLElement | null) => {
     registerCompositeNode(surfaceId, collection, node, {
       index: surfaceIndex,
       disabled,
+      text: itemText,
     });
+    content.restoreItemFocus(surfaceIndex, node);
   };
   const refHandler = ref
     ? composeRefs(
@@ -104,13 +123,17 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
     : setNode;
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(surfaceIndex),
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
+    ...itemFocusProps,
     ref: refHandler,
     id: surfaceId,
     role: 'menuitem',
+    disabled: disabled && !asChild ? true : undefined,
     'aria-disabled': disabled ? 'true' : undefined,
     'data-slot': 'menubar-item',
     'data-disabled': disabled ? 'true' : undefined,
+    tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
   });
 
   if (asChild) {
@@ -160,6 +183,7 @@ export function MenubarSubTrigger(
     disabled = false,
     onPress,
     ref,
+    textValue,
     type: typeProp,
     ...rest
   } = props;
@@ -174,6 +198,7 @@ export function MenubarSubTrigger(
 
   const { items, currentIndex, disabledItemIndexes } =
     resolveMenubarContentState(content);
+  const itemText = resolveMenuItemText(children, textValue);
   const collection = getCompositeCollection(content.contentId);
   const nav = rovingFocus({
     currentIndex,
@@ -190,22 +215,22 @@ export function MenubarSubTrigger(
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         content.setCurrentIndex(sub.surfaceIndex);
         root.setOpenPath(isOpen() ? content.path : sub.path);
         scheduleMenubarPortalSync(root);
-      }
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
   const setNode = (node: HTMLElement | null) => {
     getOverlayNodes(sub.overlayIdentity).trigger = node;
     registerCompositeNode(sub.triggerId, collection, node, {
       index: sub.surfaceIndex,
       disabled,
+      text: itemText,
     });
+    content.restoreItemFocus(sub.surfaceIndex, node);
   };
   const refHandler = ref
     ? composeRefs(
@@ -217,28 +242,46 @@ export function MenubarSubTrigger(
         setNode
       )
     : setNode;
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!disabled && content.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+
+    if (!event.defaultPrevented && event.key === 'ArrowRight') {
+      event.preventDefault();
+      content.setCurrentIndex(sub.surfaceIndex);
+      root.setOpenPath(sub.path);
+      scheduleMenubarPortalSync(root);
+    }
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (content.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
+  const itemFocusProps = nav.item(sub.surfaceIndex);
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(sub.surfaceIndex),
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
+    ...itemFocusProps,
     ref: refHandler,
     id: sub.triggerId,
     role: 'menuitem',
+    disabled: disabled && !asChild ? true : undefined,
     'aria-haspopup': 'menu',
     'aria-expanded': isOpen() ? 'true' : 'false',
     'aria-controls': sub.contentId,
     'data-slot': 'menubar-sub-trigger',
     'data-state': isOpen() ? 'open' : 'closed',
     'data-disabled': disabled ? 'true' : undefined,
+    tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
     onPointerEnter: () => {
       if (!disabled) {
-        content.setCurrentIndex(sub.surfaceIndex);
-        root.setOpenPath(sub.path);
-        scheduleMenubarPortalSync(root);
-      }
-    },
-    onKeyDown: (event: KeyboardEvent) => {
-      if (event.key === 'ArrowRight') {
-        event.preventDefault();
         content.setCurrentIndex(sub.surfaceIndex);
         root.setOpenPath(sub.path);
         scheduleMenubarPortalSync(root);

--- a/src/components/menubar/menubar-menu.tsx
+++ b/src/components/menubar/menubar-menu.tsx
@@ -4,7 +4,9 @@ import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { focusSelectedCollectionItem } from '../_internal/focus';
 import { resolvePartId } from '../_internal/id';
 import { pathIsOpen } from '../_internal/hierarchical-menu';
+import { resolveMenuItemText } from '../_internal/menu';
 import { getOverlayNodes, getPersistentPortal } from '../_internal/overlay';
+import { runCancelablePress } from '../_internal/press';
 import {
   getCompositeCollection,
   registerCompositeNode,
@@ -96,6 +98,7 @@ export function MenubarTrigger(
     disabled = false,
     onPress,
     ref,
+    textValue,
     type: typeProp,
     ...rest
   } = props;
@@ -117,17 +120,17 @@ export function MenubarTrigger(
     },
   });
   const isOpen = () => pathIsOpen(root.getOpenPath(), menu.path);
+  const itemText = resolveMenuItemText(children, textValue);
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
+        root.setCurrentTriggerIndex(menu.menuIndex);
         root.setOpenPath(isOpen() ? [] : menu.path);
         scheduleMenubarPortalSync(root);
-      }
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
   const setNode = (node: HTMLElement | null) => {
     getOverlayNodes(menu.overlayIdentity).trigger = node;
@@ -135,7 +138,9 @@ export function MenubarTrigger(
       index: menu.menuIndex,
       disabled,
       value: menu.menuKey,
+      text: itemText,
     });
+    root.restoreTriggerFocus(menu.menuIndex, node);
   };
   const refHandler = ref
     ? composeRefs(
@@ -147,31 +152,50 @@ export function MenubarTrigger(
         setNode
       )
     : setNode;
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!disabled && root.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+
+    if (!event.defaultPrevented && event.key === 'ArrowDown') {
+      event.preventDefault();
+      root.setCurrentTriggerIndex(menu.menuIndex);
+      root.setOpenPath(menu.path);
+      scheduleMenubarPortalSync(root);
+    }
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (root.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
+  const itemFocusProps = nav.item(menu.menuIndex);
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(menu.menuIndex),
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
+    ...itemFocusProps,
     ref: refHandler,
     id: menu.triggerId,
     role: 'menuitem',
+    disabled: disabled && !asChild ? true : undefined,
     'aria-haspopup': 'menu',
     'aria-expanded': isOpen() ? 'true' : 'false',
     'aria-controls': menu.contentId,
     'data-slot': 'menubar-trigger',
     'data-disabled': disabled ? 'true' : undefined,
     'data-state': isOpen() ? 'open' : 'closed',
+    tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
     onFocus: () => {
       root.setCurrentTriggerIndex(menu.menuIndex);
     },
     onPointerEnter: () => {
       if (!disabled && root.getOpenPath().length > 0) {
         root.setCurrentTriggerIndex(menu.menuIndex);
-        root.setOpenPath(menu.path);
-        scheduleMenubarPortalSync(root);
-      }
-    },
-    onKeyDown: (event: KeyboardEvent) => {
-      if (event.key === 'ArrowDown') {
-        event.preventDefault();
         root.setOpenPath(menu.path);
         scheduleMenubarPortalSync(root);
       }

--- a/src/components/menubar/menubar-root.tsx
+++ b/src/components/menubar/menubar-root.tsx
@@ -1,9 +1,19 @@
 import { cspNonce, getSignal, state } from '@askrjs/askr';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  focusCollectionItemWithRestore,
+  restorePendingCollectionItemFocus,
+  type PendingCollectionFocus,
+} from '../_internal/focus';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
 import { getCompositeCollection } from '../_internal/composite';
+import {
+  handleTypeaheadKeyDown,
+  handleTypeaheadKeyUp,
+  registerTypeaheadCleanup,
+  resetTypeahead,
+} from '../_internal/typeahead';
 import {
   captureOverlayNonce,
   createOverlayIdentity,
@@ -56,14 +66,24 @@ export function Menubar(props: MenubarProps) {
   const openPathState = state<string[]>([]);
   const portalEpochState = state(0);
   const currentTriggerIndexState = state(0);
+  const pendingTriggerFocus = state<PendingCollectionFocus>({
+    index: null,
+  })();
   const identity = state<object>({})();
+  const signal = getSignal();
+  registerTypeaheadCleanup(identity, signal);
   const portalRegistry = getMenubarPortalRegistry(identity);
   const renderedMenuKeys = new Set<string>();
   const setOpenPath = (path: string[]) => {
+    if (path.length === 0) {
+      resetTypeahead(identity);
+    }
     openPathState.set(path);
   };
   const setCurrentTriggerIndex = (index: number) => {
-    currentTriggerIndexState.set(index);
+    if (currentTriggerIndexState() !== index) {
+      currentTriggerIndexState.set(index);
+    }
   };
   const rootContextBase: MenubarRootStateInput = {
     menubarId,
@@ -71,6 +91,47 @@ export function Menubar(props: MenubarProps) {
   };
   const runtimeRenderContext = createMenubarRootRenderContext();
   const rootState = resolveMenubarRootState(rootContextBase);
+  const collection = getCompositeCollection(menubarId);
+  const syncPortals = () => {
+    portalEpochState.set(portalEpochState() + 1);
+  };
+  const navigateToTrigger = (index: number) => {
+    const menuKey = resolveMenubarRootState({
+      menubarId,
+      currentTriggerIndexCandidate: currentTriggerIndexState(),
+    }).items[index]?.menuKey;
+    setCurrentTriggerIndex(index);
+    focusCollectionItemWithRestore(
+      pendingTriggerFocus,
+      collection,
+      index,
+      menuKey === undefined
+        ? undefined
+        : () =>
+            document.getElementById(
+              resolvePartId(menubarId, `trigger-${menuKey}`)
+            )
+    );
+
+    if (openPathState().length > 0) {
+      if (menuKey) {
+        openPathState.set([menuKey]);
+        queueMicrotask(syncPortals);
+      }
+    }
+  };
+  const handleRootTypeaheadKeyDown = (event: KeyboardEvent) => {
+    const liveState = resolveMenubarRootState({
+      menubarId,
+      currentTriggerIndexCandidate: currentTriggerIndexState(),
+    });
+
+    return handleTypeaheadKeyDown(identity, event, {
+      currentIndex: liveState.currentTriggerIndex,
+      items: liveState.items,
+      onMatch: navigateToTrigger,
+    });
+  };
   const ensureMenuPortal = (menuKey: string) => {
     if (renderedMenuKeys.has(menuKey)) {
       throw new Error(
@@ -103,35 +164,37 @@ export function Menubar(props: MenubarProps) {
     setOpenPath,
     loop,
     portalEpoch: portalEpochState(),
-    syncPortals: () => {
-      portalEpochState.set(portalEpochState() + 1);
-    },
+    syncPortals,
     setCurrentTriggerIndex,
+    restoreTriggerFocus: (index, node) => {
+      restorePendingCollectionItemFocus(pendingTriggerFocus, index, node);
+    },
     resolvedState: rootState,
+    handleTypeaheadKeyDown: handleRootTypeaheadKeyDown,
+    handleTypeaheadKeyUp: (event) => handleTypeaheadKeyUp(identity, event),
   };
   for (const record of portalRegistry.byKey.values()) {
     captureOverlayNonce(record.identity, nonce);
   }
-  const collection = getCompositeCollection(menubarId);
   const nav = rovingFocus({
     currentIndex: rootState.currentTriggerIndex,
     itemCount: Math.max(rootState.items.length, 1),
     orientation: 'horizontal',
     loop,
     isDisabled: (index) => rootState.disabledTriggerIndexes.includes(index),
-    onNavigate: (index) => {
-      currentTriggerIndexState.set(index);
-      focusSelectedCollectionItem(collection, index);
-    },
+    onNavigate: navigateToTrigger,
   });
   const finalProps = mergeProps(rest, {
-    ...nav.container,
     ref,
     role: 'menubar',
     'data-slot': 'menubar',
     'data-menubar': 'true',
+    onKeyDown: (event: KeyboardEvent) => {
+      if (!handleRootTypeaheadKeyDown(event)) {
+        nav.container.onKeyDown?.(event);
+      }
+    },
   });
-  const signal = getSignal();
   queueMicrotask(() => {
     if (signal.aborted) {
       return;

--- a/src/components/menubar/menubar.shared.ts
+++ b/src/components/menubar/menubar.shared.ts
@@ -10,11 +10,13 @@ export type MenubarTriggerMetadata = {
   index: number;
   disabled: boolean;
   menuKey?: string;
+  text: string;
 };
 
 export type MenubarSurfaceMetadata = {
   index: number;
   disabled: boolean;
+  text: string;
 };
 
 export type MenubarRootContextValue = {
@@ -28,7 +30,10 @@ export type MenubarRootContextValue = {
   syncPortals: () => void;
   currentTriggerIndexCandidate: number;
   setCurrentTriggerIndex: (index: number) => void;
+  restoreTriggerFocus: (index: number, node: HTMLElement | null) => void;
   resolvedState: MenubarRootResolvedState;
+  handleTypeaheadKeyDown: (event: KeyboardEvent) => boolean;
+  handleTypeaheadKeyUp: (event: KeyboardEvent) => boolean;
 };
 
 export type MenubarPortalRecord = {
@@ -63,6 +68,10 @@ export type MenubarContentContextValue = {
   path: string[];
   currentIndexCandidate: number;
   setCurrentIndex: (index: number) => void;
+  focusItem: (index: number) => void;
+  restoreItemFocus: (index: number, node: HTMLElement | null) => void;
+  handleTypeaheadKeyDown: (event: KeyboardEvent) => boolean;
+  handleTypeaheadKeyUp: (event: KeyboardEvent) => boolean;
 };
 
 export type MenubarContentRenderContextValue = {
@@ -204,6 +213,7 @@ export function resolveMenubarRootState(
     index: item.index,
     disabled: item.disabled,
     menuKey: item.value,
+    text: item.text ?? '',
   }));
   const fallbackIndex = firstEnabledCompositeIndex(items);
   const candidateIndex = root.currentTriggerIndexCandidate;
@@ -227,6 +237,7 @@ export function resolveMenubarContentState(
   ).map((item) => ({
     index: item.index,
     disabled: item.disabled,
+    text: item.text ?? '',
   }));
   const fallbackIndex = firstEnabledCompositeIndex(items);
   const candidateIndex = content.currentIndexCandidate;

--- a/src/components/menubar/menubar.types.ts
+++ b/src/components/menubar/menubar.types.ts
@@ -21,8 +21,15 @@ export type MenubarMenuProps = {
   value?: string;
 };
 
-export type MenubarTriggerProps = ButtonLikeProps<'button', HTMLButtonElement>;
-export type MenubarTriggerAsChildProps = ButtonLikeAsChildProps;
+export type MenubarTextValueOwnProps = {
+  /** Text used for typeahead when rendered children are not plain text. */
+  textValue?: string;
+};
+
+export type MenubarTriggerProps = ButtonLikeProps<'button', HTMLButtonElement> &
+  MenubarTextValueOwnProps;
+export type MenubarTriggerAsChildProps = ButtonLikeAsChildProps &
+  MenubarTextValueOwnProps;
 
 export type MenubarPortalProps = {
   children?: unknown;
@@ -40,8 +47,10 @@ export type MenubarContentProps = BoxProps<'div', HTMLDivElement> &
 export type MenubarContentAsChildProps = BoxAsChildProps &
   MenubarContentOwnProps;
 
-export type MenubarItemProps = ButtonLikeProps<'button', HTMLButtonElement>;
-export type MenubarItemAsChildProps = ButtonLikeAsChildProps;
+export type MenubarItemProps = ButtonLikeProps<'button', HTMLButtonElement> &
+  MenubarTextValueOwnProps;
+export type MenubarItemAsChildProps = ButtonLikeAsChildProps &
+  MenubarTextValueOwnProps;
 
 export type MenubarGroupProps = BoxProps<'div', HTMLDivElement>;
 export type MenubarGroupAsChildProps = BoxAsChildProps;
@@ -60,8 +69,10 @@ export type MenubarSubProps = {
 export type MenubarSubTriggerProps = ButtonLikeProps<
   'button',
   HTMLButtonElement
->;
-export type MenubarSubTriggerAsChildProps = ButtonLikeAsChildProps;
+> &
+  MenubarTextValueOwnProps;
+export type MenubarSubTriggerAsChildProps = ButtonLikeAsChildProps &
+  MenubarTextValueOwnProps;
 
 export type MenubarSubContentProps = BoxProps<'div', HTMLDivElement> &
   MenubarContentOwnProps;

--- a/src/components/popover/popover-close.tsx
+++ b/src/components/popover/popover-close.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
+import { runCancelablePress } from '../_internal/press';
 import { readPopoverRootContext } from './popover.shared';
 import type {
   PopoverCloseAsChildProps,
@@ -25,11 +26,9 @@ export function PopoverClose(
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(false);
-      }
+      });
     },
     isNativeButton: !asChild,
   });

--- a/src/components/popover/popover-trigger.tsx
+++ b/src/components/popover/popover-trigger.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
+import { runCancelablePress } from '../_internal/press';
 import { readPopoverRootContext } from './popover.shared';
 import type {
   PopoverTriggerAsChildProps,
@@ -25,11 +26,9 @@ export function PopoverTrigger(
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(!root.open);
-      }
+      });
     },
     isNativeButton: !asChild,
   });

--- a/src/components/radio-group/radio-group-item.tsx
+++ b/src/components/radio-group/radio-group-item.tsx
@@ -56,6 +56,7 @@ export function RadioGroupItem(
     },
     isNativeButton: !asChild,
   });
+  const itemFocusProps = nav.item(itemIndex);
   const setNode = (node: HTMLElement | null) => {
     const changed = registerCompositeNode(itemId, collection, node, {
       index: itemIndex,
@@ -79,7 +80,7 @@ export function RadioGroupItem(
     : setNode;
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(itemIndex),
+    ...itemFocusProps,
     ref: refHandler,
     id: itemId,
     role: 'radio',
@@ -87,7 +88,7 @@ export function RadioGroupItem(
     'data-slot': 'radio-group-item',
     'data-disabled': isDisabled ? 'true' : undefined,
     'data-state': checked ? 'checked' : 'unchecked',
-    tabIndex: isDisabled && asChild ? -1 : undefined,
+    tabIndex: isDisabled ? -1 : itemFocusProps.tabIndex,
     value,
   });
 

--- a/src/components/scroll-area/scroll-area.tsx
+++ b/src/components/scroll-area/scroll-area.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
-import { mergeProps } from '@askrjs/askr/foundations/utilities';
+import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
-import { readScope, defineScope } from '@askrjs/askr';
+import { getSignal, readScope, defineScope, state } from '@askrjs/askr';
 import type {
   ScrollAreaAsChildProps,
   ScrollAreaCornerProps,
@@ -15,14 +15,34 @@ import type {
 type ScrollAreaRootContextValue = {
   scrollAreaId: string;
   viewportId: string;
-  scrollbarId: string;
-  thumbId: string;
   cornerId: string;
+  setViewport: (node: HTMLElement | null) => void;
+  setScrollbar: (
+    orientation: 'vertical' | 'horizontal',
+    node: HTMLElement | null
+  ) => void;
+  syncMetrics: () => void;
+  metrics: (orientation: 'vertical' | 'horizontal') => ScrollMetrics;
+  scroll: (orientation: 'vertical' | 'horizontal', key: string) => boolean;
+};
+
+type ScrollMetrics = { overflow: boolean; percentage: number };
+type ScrollAreaEntry = {
+  viewport: HTMLElement | null;
+  observer: ResizeObserver | null;
+  resizeFrame: number | null;
+  cleanupSignal: AbortSignal | null;
+  metrics: Record<'vertical' | 'horizontal', ScrollMetrics>;
+  scrollbars: Map<'vertical' | 'horizontal', HTMLElement>;
 };
 
 const ScrollAreaRootContext = defineScope<ScrollAreaRootContextValue | null>(
   null
 );
+const ScrollAreaScrollbarContext = defineScope<{
+  orientation: 'vertical' | 'horizontal';
+  thumbId: string;
+} | null>(null);
 
 function readScrollAreaRootContext(): ScrollAreaRootContextValue {
   const context = readScope(ScrollAreaRootContext);
@@ -40,16 +60,159 @@ export function ScrollArea(props: ScrollAreaProps | ScrollAreaAsChildProps) {
   const { children, id } = props;
   const scrollAreaId = resolveCompoundId('scroll-area', id, children);
   const viewportId = resolvePartId(scrollAreaId, 'viewport');
-  const scrollbarId = resolvePartId(scrollAreaId, 'scrollbar');
-  const thumbId = resolvePartId(scrollAreaId, 'thumb');
   const cornerId = resolvePartId(scrollAreaId, 'corner');
+  const entry = state<ScrollAreaEntry>({
+    viewport: null,
+    observer: null,
+    resizeFrame: null,
+    cleanupSignal: null,
+    metrics: {
+      vertical: { overflow: false, percentage: 0 },
+      horizontal: { overflow: false, percentage: 0 },
+    },
+    scrollbars: new Map(),
+  })();
+
+  const syncMetrics = () => {
+    const viewport = entry.viewport;
+    if (!viewport) {
+      return;
+    }
+    const maxTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+    const maxLeft = Math.max(0, viewport.scrollWidth - viewport.clientWidth);
+    const nextVertical = {
+      overflow: maxTop > 0,
+      percentage: maxTop > 0 ? (viewport.scrollTop / maxTop) * 100 : 0,
+    };
+    const nextHorizontal = {
+      overflow: maxLeft > 0,
+      percentage: maxLeft > 0 ? (viewport.scrollLeft / maxLeft) * 100 : 0,
+    };
+    entry.metrics.vertical = nextVertical;
+    entry.metrics.horizontal = nextHorizontal;
+    for (const orientation of ['vertical', 'horizontal'] as const) {
+      const scrollbar = entry.scrollbars.get(orientation);
+      const metrics = entry.metrics[orientation];
+      if (!scrollbar) {
+        continue;
+      }
+      scrollbar.setAttribute(
+        'aria-valuenow',
+        String(Math.round(metrics.percentage))
+      );
+      scrollbar.setAttribute(
+        'aria-disabled',
+        metrics.overflow ? 'false' : 'true'
+      );
+      scrollbar.tabIndex = metrics.overflow ? 0 : -1;
+      scrollbar.dataset.state = metrics.overflow ? 'visible' : 'hidden';
+    }
+  };
+
+  const setViewport = (node: HTMLElement | null) => {
+    if (entry.viewport === node) {
+      return;
+    }
+    entry.observer?.disconnect();
+    entry.observer = null;
+    entry.viewport = node;
+    if (!node) {
+      return;
+    }
+    queueMicrotask(syncMetrics);
+    if (typeof ResizeObserver !== 'undefined') {
+      entry.observer = new ResizeObserver(() => {
+        if (entry.resizeFrame !== null) {
+          cancelAnimationFrame(entry.resizeFrame);
+        }
+        entry.resizeFrame = requestAnimationFrame(() => {
+          entry.resizeFrame = null;
+          syncMetrics();
+        });
+      });
+      entry.observer.observe(node);
+      if (node.firstElementChild) {
+        entry.observer.observe(node.firstElementChild);
+      }
+    }
+  };
+
+  const signal = getSignal();
+  if (entry.cleanupSignal !== signal) {
+    entry.cleanupSignal = signal;
+    signal.addEventListener(
+      'abort',
+      () => {
+        entry.observer?.disconnect();
+        if (entry.resizeFrame !== null) {
+          cancelAnimationFrame(entry.resizeFrame);
+        }
+        entry.observer = null;
+        entry.resizeFrame = null;
+        entry.viewport = null;
+        entry.scrollbars.clear();
+      },
+      { once: true }
+    );
+  }
 
   const rootContext: ScrollAreaRootContextValue = {
     scrollAreaId,
     viewportId,
-    scrollbarId,
-    thumbId,
     cornerId,
+    setViewport,
+    setScrollbar: (orientation, node) => {
+      if (node) {
+        entry.scrollbars.set(orientation, node);
+        queueMicrotask(syncMetrics);
+      } else {
+        entry.scrollbars.delete(orientation);
+      }
+    },
+    syncMetrics,
+    metrics: (orientation) => entry.metrics[orientation],
+    scroll: (orientation, key) => {
+      const viewport = entry.viewport;
+      if (!viewport) {
+        return false;
+      }
+      const vertical = orientation === 'vertical';
+      const current = vertical ? viewport.scrollTop : viewport.scrollLeft;
+      const viewportSize = vertical
+        ? viewport.clientHeight
+        : viewport.clientWidth;
+      const maximum = vertical
+        ? viewport.scrollHeight - viewport.clientHeight
+        : viewport.scrollWidth - viewport.clientWidth;
+      const delta =
+        key === 'ArrowUp' || key === 'ArrowLeft'
+          ? -40
+          : key === 'ArrowDown' || key === 'ArrowRight'
+            ? 40
+            : key === 'PageUp'
+              ? -viewportSize
+              : key === 'PageDown'
+                ? viewportSize
+                : null;
+      const next =
+        key === 'Home'
+          ? 0
+          : key === 'End'
+            ? maximum
+            : delta === null
+              ? null
+              : current + delta;
+      if (next === null) {
+        return false;
+      }
+      if (vertical) {
+        viewport.scrollTop = next;
+      } else {
+        viewport.scrollLeft = next;
+      }
+      syncMetrics();
+      return true;
+    },
   };
 
   return (
@@ -71,11 +234,26 @@ export function ScrollAreaViewport(
   const { asChild, children, ref, style: _style, ...rest } = props;
   const root = readScrollAreaRootContext();
   const finalProps = mergeProps(rest, {
-    ref,
+    ref: composeRefs(
+      ref as
+        | ((value: HTMLElement | null) => void)
+        | { current: HTMLElement | null }
+        | null
+        | undefined,
+      (node: HTMLElement | null) => {
+        root.setViewport(node);
+      }
+    ),
     id: root.viewportId,
     role: 'region',
     tabIndex: 0,
     'data-slot': 'scroll-area-viewport',
+    onScroll: (event: Event) => {
+      if (event.currentTarget instanceof HTMLElement) {
+        root.setViewport(event.currentTarget);
+      }
+      root.syncMetrics();
+    },
   });
 
   if (asChild) {
@@ -96,27 +274,64 @@ export function ScrollAreaScrollbar(
     ...rest
   } = props;
   const root = readScrollAreaRootContext();
+  const metrics = root.metrics(orientation);
+  const scrollbarId = resolvePartId(
+    root.scrollAreaId,
+    `scrollbar-${orientation}`
+  );
+  const thumbId = resolvePartId(root.scrollAreaId, `thumb-${orientation}`);
   const finalProps = mergeProps(rest, {
-    ref,
-    id: root.scrollbarId,
+    ref: composeRefs(ref, (node: HTMLElement | null) =>
+      root.setScrollbar(orientation, node)
+    ),
+    id: scrollbarId,
     role: 'scrollbar',
     'aria-controls': root.viewportId,
     'aria-orientation': orientation,
-    tabIndex: 0,
+    'aria-valuemin': '0',
+    'aria-valuemax': '100',
+    'aria-valuenow': String(Math.round(metrics.percentage)),
+    'aria-disabled': metrics.overflow ? undefined : 'true',
+    tabIndex: metrics.overflow ? 0 : -1,
     'data-slot': 'scroll-area-scrollbar',
     'data-orientation': orientation,
-    'data-state': 'visible',
+    'data-state': metrics.overflow ? 'visible' : 'hidden',
+    onKeyDown: (event: KeyboardEvent) => {
+      const orientationKey =
+        orientation === 'vertical'
+          ? ['ArrowUp', 'ArrowDown']
+          : ['ArrowLeft', 'ArrowRight'];
+      if (
+        !orientationKey.includes(event.key) &&
+        !['PageUp', 'PageDown', 'Home', 'End'].includes(event.key)
+      ) {
+        return;
+      }
+      if (root.scroll(orientation, event.key)) {
+        event.preventDefault();
+      }
+    },
   });
 
-  return <div {...finalProps}>{children}</div>;
+  return (
+    <ScrollAreaScrollbarContext value={{ orientation, thumbId }}>
+      <div {...finalProps}>{children}</div>
+    </ScrollAreaScrollbarContext>
+  );
 }
 
 export function ScrollAreaThumb(props: ScrollAreaThumbProps): JSX.Element {
   const { children, ref, style: _style, ...rest } = props;
-  const root = readScrollAreaRootContext();
+  readScrollAreaRootContext();
+  const scrollbar = readScope(ScrollAreaScrollbarContext);
+  if (!scrollbar) {
+    throw new Error(
+      'ScrollAreaThumb must be used within <ScrollAreaScrollbar>'
+    );
+  }
   const finalProps = mergeProps(rest, {
     ref,
-    id: root.thumbId,
+    id: scrollbar.thumbId,
     'data-slot': 'scroll-area-thumb',
   });
 

--- a/src/components/select/select-content.tsx
+++ b/src/components/select/select-content.tsx
@@ -3,7 +3,10 @@ import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { DismissableLayer } from '../dismissable-layer';
 import { FocusScope } from '../focus-scope';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  dismissPopupWithTab,
+  focusSelectedCollectionItem,
+} from '../_internal/focus';
 import { getMenuCollection } from '../_internal/menu';
 import {
   clearOverlayPosition,
@@ -55,11 +58,10 @@ export function SelectContent(
     isDisabled: (index) => disabledIndexes.includes(index),
     onNavigate: (index) => {
       root.setCurrentIndex(index);
-      focusSelectedCollectionItem(collection, index);
+      root.focusItem(index);
     },
   });
   const finalProps = mergeProps(rest, {
-    ...nav.container,
     ref: composeRefs(
       ref as
         | ((value: HTMLElement | null) => void)
@@ -92,6 +94,26 @@ export function SelectContent(
     'data-side': side,
     'data-align': align,
     'data-side-offset': String(sideOffset),
+    onKeyDown: (event: KeyboardEvent) => {
+      if (root.handleTypeaheadKeyDown(event)) {
+        return;
+      }
+
+      nav.container.onKeyDown?.(event);
+
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      dismissPopupWithTab(
+        event,
+        overlayNodes.trigger,
+        overlayNodes.content ? [overlayNodes.content] : [],
+        () => {
+          root.setOpen(false);
+        }
+      );
+    },
   });
   const contentNode = asChild ? (
     <Slot asChild {...finalProps} children={children} />

--- a/src/components/select/select-item.tsx
+++ b/src/components/select/select-item.tsx
@@ -1,13 +1,13 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
 import {
   getMenuCollection,
   registerCollectionNode,
   resolveMenuItemText,
 } from '../_internal/menu';
 import { resolvePartId } from '../_internal/id';
+import { runCancelablePress } from '../_internal/press';
 import {
   readSelectRenderContext,
   readSelectRootContext,
@@ -55,26 +55,41 @@ export function SelectItem(props: SelectItemProps | SelectItemAsChildProps) {
       }
 
       root.setCurrentIndex(index);
-      focusSelectedCollectionItem(collection, index);
+      root.focusItem(index);
     },
   });
   const selected = root.value === value;
   const interactionProps = pressable({
     disabled: isDisabled,
     onPress: (event) => {
-      if (event.defaultPrevented) {
-        return;
-      }
-
-      root.setValue(value);
-      root.setCurrentIndex(itemIndex);
-      root.setOpen(false);
+      runCancelablePress(event, undefined, () => {
+        root.setValue(value);
+        root.setCurrentIndex(itemIndex);
+        root.setOpen(false);
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
+  const itemFocusProps = nav.item(itemIndex);
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!isDisabled && root.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (root.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(itemIndex),
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
+    ...itemFocusProps,
     ref: composeRefs(
       ref as
         | ((value: HTMLElement | null) => void)
@@ -88,16 +103,18 @@ export function SelectItem(props: SelectItemProps | SelectItemAsChildProps) {
           value,
           text: itemText,
         });
+        root.restoreItemFocus(itemIndex, node);
       }
     ),
     id: itemId,
     role: 'option',
-    tabIndex: isDisabled ? -1 : undefined,
+    disabled: isDisabled && !asChild ? true : undefined,
     'aria-selected': selected ? 'true' : 'false',
     'data-slot': 'select-item',
     'data-state': selected ? 'checked' : 'unchecked',
     'data-disabled': isDisabled ? 'true' : undefined,
     'aria-disabled': isDisabled ? 'true' : undefined,
+    tabIndex: isDisabled ? -1 : itemFocusProps.tabIndex,
   });
 
   if (asChild) {

--- a/src/components/select/select-root.tsx
+++ b/src/components/select/select-root.tsx
@@ -1,13 +1,25 @@
-import { cspNonce, state } from '@askrjs/askr';
+import { cspNonce, getSignal, state } from '@askrjs/askr';
 import { controllableState } from '@askrjs/askr/foundations/state';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
 import { collectJsxElements } from '../_internal/jsx';
 import {
   captureOverlayNonce,
   createOverlayIdentity,
+  getOverlayNodes,
   getPersistentPortal,
 } from '../_internal/overlay';
-import { resolveMenuItemText } from '../_internal/menu';
+import {
+  focusCollectionItemWithRestore,
+  restorePendingCollectionItemFocus,
+  type PendingCollectionFocus,
+} from '../_internal/focus';
+import { getMenuCollection, resolveMenuItemText } from '../_internal/menu';
+import {
+  handleTypeaheadKeyDown,
+  handleTypeaheadKeyUp,
+  registerTypeaheadCleanup,
+  resetTypeahead,
+} from '../_internal/typeahead';
 import { SelectItem } from './select-item';
 import {
   createSelectRenderContext,
@@ -34,6 +46,7 @@ export function Select(props: SelectProps) {
   const selectId = resolveCompoundId('select', id, children);
   const overlayIdentity = state(createOverlayIdentity())();
   captureOverlayNonce(overlayIdentity, cspNonce());
+  registerTypeaheadCleanup(overlayIdentity, getSignal());
   const valueState = controllableState({
     value,
     defaultValue,
@@ -44,7 +57,6 @@ export function Select(props: SelectProps) {
     defaultValue: defaultOpen,
     onChange: onOpenChange,
   });
-  const currentIndexState = state(0);
   const declaredItems = collectJsxElements(
     children,
     (element) => element.type === SelectItem
@@ -59,24 +71,98 @@ export function Select(props: SelectProps) {
       element.props?.textValue as string | undefined
     ),
   }));
+  const declaredSelectedIndex = declaredItems.findIndex(
+    (item) => item.value === valueState()
+  );
+  const currentIndexState = state(
+    declaredSelectedIndex >= 0 ? declaredSelectedIndex : 0
+  );
+  const pendingFocus = state<PendingCollectionFocus>({ index: null })();
+  const setCurrentIndex = (index: number) => {
+    if (currentIndexState() !== index) {
+      currentIndexState.set(index);
+    }
+  };
   const rootContextBase = {
     selectId,
     overlayIdentity,
     value: valueState(),
+    open: openState(),
     currentIndexCandidate: currentIndexState(),
     disabled,
     declaredItems,
   };
   const resolvedState = resolveSelectState(rootContextBase);
+  const collection = getMenuCollection(selectId);
+  const focusItem = (index: number) => {
+    const itemValue = resolvedState.items[index]?.value;
+    focusCollectionItemWithRestore(
+      pendingFocus,
+      collection,
+      index,
+      itemValue === undefined
+        ? undefined
+        : () =>
+            document.getElementById(
+              resolvePartId(selectId, `item-${itemValue}`)
+            )
+    );
+  };
+  const setOpen = (nextOpen: boolean) => {
+    resetTypeahead(overlayIdentity);
+
+    if (nextOpen && !openState()) {
+      const liveClosedState = resolveSelectState({
+        ...rootContextBase,
+        value: valueState(),
+        open: false,
+        currentIndexCandidate: currentIndexState(),
+      });
+      setCurrentIndex(liveClosedState.currentIndex);
+    }
+
+    openState.set(nextOpen);
+  };
   const rootContext: SelectRootContextValue = {
     ...rootContextBase,
     open: openState(),
-    setOpen: openState.set,
+    setOpen,
     contentId: resolvePartId(selectId, 'content'),
     portal: getPersistentPortal(overlayIdentity),
     setValue: valueState.set,
-    setCurrentIndex: currentIndexState.set,
+    setCurrentIndex,
+    focusItem,
+    restoreItemFocus: (index, node) => {
+      restorePendingCollectionItemFocus(pendingFocus, index, node);
+    },
     resolvedState,
+    handleTypeaheadKeyDown: (event) =>
+      handleTypeaheadKeyDown(overlayIdentity, event, {
+        currentIndex: resolvedState.currentIndex,
+        items: resolvedState.items,
+        onMatch: (index) => {
+          const item = resolvedState.items[index];
+          setCurrentIndex(index);
+
+          if (openState()) {
+            focusItem(index);
+          } else if (item?.value !== undefined) {
+            const trigger = getOverlayNodes(overlayIdentity).trigger;
+            const restoreTriggerFocus = trigger === document.activeElement;
+            valueState.set(item.value);
+
+            if (restoreTriggerFocus) {
+              queueMicrotask(() => {
+                queueMicrotask(() => {
+                  getOverlayNodes(overlayIdentity).trigger?.focus();
+                });
+              });
+            }
+          }
+        },
+      }),
+    handleTypeaheadKeyUp: (event) =>
+      handleTypeaheadKeyUp(overlayIdentity, event),
   };
   const runtimeRenderContext = createSelectRenderContext();
   const PortalHost = rootContext.portal;

--- a/src/components/select/select-trigger.tsx
+++ b/src/components/select/select-trigger.tsx
@@ -2,6 +2,7 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import { getOverlayNodes } from '../_internal/overlay';
+import { runCancelablePress } from '../_internal/press';
 import { readSelectRootContext } from './select.shared';
 import type {
   SelectPortalProps,
@@ -34,15 +35,40 @@ export function SelectTrigger(
   const interactionProps = pressable({
     disabled: isDisabled,
     onPress: (event) => {
-      onPress?.(event);
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(!root.open);
-      }
+      });
     },
-    isNativeButton: !asChild,
+    isNativeButton: false,
   });
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (!isDisabled && root.handleTypeaheadKeyDown(event)) {
+      return;
+    }
+
+    interactionProps.onKeyDown?.(event);
+
+    if (event.defaultPrevented || isDisabled) {
+      return;
+    }
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      root.setOpen(true);
+      return;
+    }
+  };
+  const handleKeyUp = (event: KeyboardEvent) => {
+    if (root.handleTypeaheadKeyUp(event)) {
+      return;
+    }
+
+    interactionProps.onKeyUp?.(event);
+  };
   const finalProps = mergeProps(rest, {
     ...interactionProps,
+    onKeyDown: handleKeyDown,
+    onKeyUp: handleKeyUp,
     ref: composeRefs(
       ref as
         | ((value: HTMLElement | null) => void)
@@ -56,6 +82,7 @@ export function SelectTrigger(
     'aria-haspopup': 'listbox',
     'aria-expanded': root.open ? 'true' : 'false',
     'aria-controls': root.contentId,
+    disabled: isDisabled && !asChild ? true : undefined,
     'data-slot': 'select-trigger',
     'data-disabled': isDisabled ? 'true' : undefined,
     'data-size': size && size !== 'md' ? size : undefined,

--- a/src/components/select/select.shared.ts
+++ b/src/components/select/select.shared.ts
@@ -9,6 +9,7 @@ import type { OverlayPortal } from '../_internal/overlay';
 export type SelectStateInput = {
   selectId: string;
   value: string;
+  open: boolean;
   currentIndexCandidate: number;
   disabled: boolean;
   declaredItems: SelectItemMetadata[];
@@ -31,9 +32,13 @@ export type SelectRootContextValue = {
   setValue: (value: string) => void;
   currentIndexCandidate: number;
   setCurrentIndex: (index: number) => void;
+  focusItem: (index: number) => void;
+  restoreItemFocus: (index: number, node: HTMLElement | null) => void;
   disabled: boolean;
   declaredItems: SelectItemMetadata[];
   resolvedState: SelectResolvedState;
+  handleTypeaheadKeyDown: (event: KeyboardEvent) => boolean;
+  handleTypeaheadKeyUp: (event: KeyboardEvent) => boolean;
 };
 
 export type SelectRenderContextValue = {
@@ -135,14 +140,18 @@ export function resolveSelectState(
     items.length > 0 && effectiveItems.every((item) => item.disabled);
   const candidateIndex = root.currentIndexCandidate;
   const currentIndex =
-    selectedIndex >= 0 && !effectiveItems[selectedIndex]?.disabled
-      ? selectedIndex
-      : effectiveItems[candidateIndex] &&
-          !effectiveItems[candidateIndex]?.disabled
-        ? candidateIndex
-        : allItemsDisabled
-          ? -1
-          : fallbackIndex;
+    root.open &&
+    effectiveItems[candidateIndex] &&
+    !effectiveItems[candidateIndex]?.disabled
+      ? candidateIndex
+      : selectedIndex >= 0 && !effectiveItems[selectedIndex]?.disabled
+        ? selectedIndex
+        : effectiveItems[candidateIndex] &&
+            !effectiveItems[candidateIndex]?.disabled
+          ? candidateIndex
+          : allItemsDisabled
+            ? -1
+            : fallbackIndex;
 
   return {
     items,

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -22,6 +22,7 @@ import { Presence, Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { controllableState } from '@askrjs/askr/foundations/state';
 import { pressable } from '@askrjs/askr/foundations/interactions';
+import { runCancelablePress } from '../_internal/press';
 import { state } from '@askrjs/askr';
 import { resource } from '@askrjs/askr/resources';
 import { DismissableLayer } from '../dismissable-layer';
@@ -521,11 +522,9 @@ export function ToastAction(props: ToastActionProps | ToastActionAsChildProps) {
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(false);
-      }
+      });
     },
     isNativeButton: !asChild,
   });
@@ -567,11 +566,9 @@ export function ToastClose(props: ToastCloseProps | ToastCloseAsChildProps) {
   const interactionProps = pressable({
     disabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         root.setOpen(false);
-      }
+      });
     },
     isNativeButton: !asChild,
   });

--- a/src/components/toggle-group/toggle-group-item.tsx
+++ b/src/components/toggle-group/toggle-group-item.tsx
@@ -2,6 +2,7 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { focusSelectedCollectionItem } from '../_internal/focus';
+import { runCancelablePress } from '../_internal/press';
 import {
   getCompositeCollection,
   registerCompositeNode,
@@ -59,9 +60,7 @@ export function ToggleGroupItem(
   const interactionProps = pressable({
     disabled: isDisabled,
     onPress: (event) => {
-      onPress?.(event);
-
-      if (!event.defaultPrevented) {
+      runCancelablePress(event, onPress, () => {
         const nextValue = toggleDisclosureValue(
           root.type,
           root.getValue(),
@@ -70,13 +69,14 @@ export function ToggleGroupItem(
         );
         root.setValue(nextValue);
         root.setCurrentIndex(itemIndex);
-      }
+      });
     },
     isNativeButton: !asChild,
   });
+  const itemFocusProps = nav.item(itemIndex);
   const finalProps = mergeProps(rest, {
     ...interactionProps,
-    ...nav.item(itemIndex),
+    ...itemFocusProps,
     ref: composeRefs(
       ref as
         | ((value: HTMLElement | null) => void)
@@ -100,7 +100,7 @@ export function ToggleGroupItem(
     'data-slot': 'toggle-group-item',
     'data-state': pressed ? 'on' : 'off',
     'data-disabled': isDisabled ? 'true' : undefined,
-    tabIndex: isDisabled && asChild ? -1 : undefined,
+    tabIndex: isDisabled ? -1 : itemFocusProps.tabIndex,
   });
 
   if (asChild) {

--- a/tests/browser/components/accordion/behavior.test.tsx
+++ b/tests/browser/components/accordion/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 import {
   Accordion,
@@ -154,6 +155,45 @@ describe('Accordion - Behavior', () => {
         `[${ACCORDION_A11Y_CONTRACT.EXPANDED_ATTRIBUTE}="true"]`
       )
     ).toHaveLength(2);
+  });
+
+  it('should activates an asChild trigger with Enter and Space', async () => {
+    container = mount(
+      <Accordion collapsible>
+        <AccordionItem value="details">
+          <AccordionHeader>
+            <AccordionTrigger asChild>
+              <span>Details</span>
+            </AccordionTrigger>
+          </AccordionHeader>
+          <AccordionContent>Body</AccordionContent>
+        </AccordionItem>
+      </Accordion>
+    );
+    await flushUpdates();
+
+    let trigger = container.querySelector(
+      '[data-slot="accordion-trigger"]'
+    ) as HTMLElement;
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="accordion-trigger"]'
+    ) as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(container.textContent).toContain('Body');
+
+    trigger.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="accordion-trigger"]'
+    ) as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(container.textContent).not.toContain('Body');
   });
 
   it('should keep controlled state props off the native root', () => {

--- a/tests/browser/components/button/behavior.test.tsx
+++ b/tests/browser/components/button/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
 import { Link } from '@askrjs/askr/router';
@@ -171,6 +172,23 @@ describe('Button - Behavior', () => {
       new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })
     );
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('should activates a non-native asChild host with Enter and Space', async () => {
+    const onPress = vi.fn();
+    container = mount(
+      <Button asChild onPress={onPress}>
+        <span>Save</span>
+      </Button>
+    );
+
+    const host = container.querySelector('[role="button"]') as HTMLElement;
+    host.focus();
+    await userEvent.keyboard('{Enter}');
+    host.focus();
+    await userEvent.keyboard(' ');
+
+    expect(onPress).toHaveBeenCalledTimes(2);
   });
 
   it('should replaces stateful icon children instead of accumulating them', async () => {

--- a/tests/browser/components/checkbox/behavior.test.tsx
+++ b/tests/browser/components/checkbox/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
 import { Checkbox } from '../../../../src/components/checkbox/checkbox';
@@ -137,5 +138,56 @@ describe('Checkbox - Behavior', () => {
 
     expect(div).toBeTruthy();
     expect(refNode).toBe(div);
+  });
+
+  it('should toggles an asChild host with Enter and Space', async () => {
+    const onCheckedChange = vi.fn();
+    container = mount(
+      <Checkbox asChild onCheckedChange={onCheckedChange}>
+        <span>Remember me</span>
+      </Checkbox>
+    );
+
+    let checkbox = container.querySelector(
+      '[data-slot="checkbox"]'
+    ) as HTMLElement;
+    checkbox.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+
+    checkbox = container.querySelector('[data-slot="checkbox"]') as HTMLElement;
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+
+    checkbox.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    checkbox = container.querySelector('[data-slot="checkbox"]') as HTMLElement;
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    expect(onCheckedChange.mock.calls).toEqual([[true], [false]]);
+  });
+
+  it('should honors caller cancellation for asChild keyboard presses', async () => {
+    const onCheckedChange = vi.fn();
+    container = mount(
+      <Checkbox
+        asChild
+        onPress={(event) => event.preventDefault?.()}
+        onCheckedChange={onCheckedChange}
+      >
+        <span>Remember me</span>
+      </Checkbox>
+    );
+
+    const checkbox = container.querySelector(
+      '[data-slot="checkbox"]'
+    ) as HTMLElement;
+    checkbox.focus();
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    expect(onCheckedChange).not.toHaveBeenCalled();
   });
 });

--- a/tests/browser/components/collapsible/a11y.test.tsx
+++ b/tests/browser/components/collapsible/a11y.test.tsx
@@ -134,64 +134,6 @@ describe('Collapsible — Accessibility', () => {
   });
 
   describe('Keyboard Navigation', () => {
-    it('should toggle on Enter key', () => {
-      container = mount(
-        <Collapsible defaultOpen={false}>
-          <CollapsibleTrigger>Toggle</CollapsibleTrigger>
-          <CollapsibleContent>Content</CollapsibleContent>
-        </Collapsible>
-      );
-
-      const trigger = container.querySelector('button')!;
-      document.body.appendChild(container);
-      trigger.focus();
-
-      const event = new KeyboardEvent('keydown', {
-        key: 'Enter',
-        bubbles: true,
-      });
-      trigger.dispatchEvent(event);
-
-      // Should be open after Enter
-      const expanded = container
-        .querySelector('button')
-        ?.getAttribute('aria-expanded');
-      expect(expanded).toBe('true');
-    });
-
-    it('should toggle on Space key', () => {
-      container = mount(
-        <Collapsible defaultOpen={false}>
-          <CollapsibleTrigger>Toggle</CollapsibleTrigger>
-          <CollapsibleContent>Content</CollapsibleContent>
-        </Collapsible>
-      );
-
-      const trigger = container.querySelector('button')!;
-      document.body.appendChild(container);
-      trigger.focus();
-
-      const event = new KeyboardEvent('keydown', {
-        key: ' ',
-        code: 'Space',
-        bubbles: true,
-      });
-      trigger.dispatchEvent(event);
-
-      const keyup = new KeyboardEvent('keyup', {
-        key: ' ',
-        code: 'Space',
-        bubbles: true,
-      });
-      trigger.dispatchEvent(keyup);
-
-      // Should be open after Space
-      const expanded = container
-        .querySelector('button')
-        ?.getAttribute('aria-expanded');
-      expect(expanded).toBe('true');
-    });
-
     it('should be focusable when not disabled', () => {
       container = mount(
         <Collapsible>

--- a/tests/browser/components/collapsible/behavior.test.tsx
+++ b/tests/browser/components/collapsible/behavior.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
+import { userEvent } from '@vitest/browser/context';
 import { Button } from '../../../../src/components/button';
 import {
   Collapsible,
@@ -145,6 +146,64 @@ describe('Collapsible — Behavior', () => {
       const span = container.querySelector('span');
       expect(span).toBeDefined();
       expect(span?.textContent).toBe('Custom Trigger');
+    });
+
+    it('should toggles exactly once with Enter and Space on native and asChild triggers', async () => {
+      const onNativeOpenChange = vi.fn();
+      container = mount(
+        <Collapsible onOpenChange={onNativeOpenChange}>
+          <CollapsibleTrigger>Native trigger</CollapsibleTrigger>
+          <CollapsibleContent>Native content</CollapsibleContent>
+        </Collapsible>
+      );
+
+      let trigger = container.querySelector('button') as HTMLButtonElement;
+      trigger.focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(onNativeOpenChange).toHaveBeenCalledTimes(1);
+      expect(onNativeOpenChange).toHaveBeenLastCalledWith(true);
+      expect(container.textContent).toContain('Native content');
+
+      trigger = container.querySelector('button') as HTMLButtonElement;
+      trigger.focus();
+      await userEvent.keyboard(' ');
+
+      expect(onNativeOpenChange).toHaveBeenCalledTimes(2);
+      expect(onNativeOpenChange).toHaveBeenLastCalledWith(false);
+      expect(container.textContent).not.toContain('Native content');
+
+      unmount(container);
+
+      const onChildOpenChange = vi.fn();
+      container = mount(
+        <Collapsible onOpenChange={onChildOpenChange}>
+          <CollapsibleTrigger asChild>
+            <span>Child trigger</span>
+          </CollapsibleTrigger>
+          <CollapsibleContent>Child content</CollapsibleContent>
+        </Collapsible>
+      );
+
+      let childTrigger = container.querySelector(
+        '[data-collapsible-trigger="true"]'
+      ) as HTMLElement;
+      childTrigger.focus();
+      await userEvent.keyboard('{Enter}');
+
+      expect(onChildOpenChange).toHaveBeenCalledTimes(1);
+      expect(onChildOpenChange).toHaveBeenLastCalledWith(true);
+      expect(container.textContent).toContain('Child content');
+
+      childTrigger = container.querySelector(
+        '[data-collapsible-trigger="true"]'
+      ) as HTMLElement;
+      childTrigger.focus();
+      await userEvent.keyboard(' ');
+
+      expect(onChildOpenChange).toHaveBeenCalledTimes(2);
+      expect(onChildOpenChange).toHaveBeenLastCalledWith(false);
+      expect(container.textContent).not.toContain('Child content');
     });
 
     it('should preserves button styling props when trigger composes as child', () => {

--- a/tests/browser/components/cross-component/behavior.test.tsx
+++ b/tests/browser/components/cross-component/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
+import { createIsland } from '@askrjs/askr/boot';
 import { Checkbox } from '../../../../src/components/checkbox';
 import {
   Dialog,
@@ -24,13 +25,19 @@ describe('Cross-component contracts', () => {
   });
 
   it('should preserve controlled-to-uncontrolled state transitions given native controls when the value or checked prop changes from defined to undefined', async () => {
-    const checked = state<boolean | undefined>(true);
-    container = mount(
-      <Checkbox
-        checked={checked()}
-        onCheckedChange={(next) => checked.set(next)}
-      />
-    );
+    let checked!: ReturnType<typeof state<boolean | undefined>>;
+    function ControlledCheckbox() {
+      checked = state<boolean | undefined>(true);
+      return (
+        <Checkbox
+          checked={checked()}
+          onCheckedChange={(next) => checked.set(next)}
+        />
+      );
+    }
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    createIsland({ root: container, component: ControlledCheckbox });
     await flushUpdates();
     expect(
       container
@@ -85,6 +92,7 @@ describe('Cross-component contracts', () => {
       <VirtualList
         items={[{ id: 'a' }, { id: 'b' }]}
         rowHeight={24}
+        overscan={2}
         getKey={(item) => item.id}
         rowComponent={({ item }) => <div>{item.id}</div>}
       />

--- a/tests/browser/components/dialog/behavior.test.tsx
+++ b/tests/browser/components/dialog/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
 import { Button } from '../../../../src/components/button';
@@ -178,6 +179,49 @@ describe('Dialog - Behavior', () => {
     expect(close.getAttribute('data-variant')).toBe('outline');
 
     close.click();
+    await flushUpdates();
+
+    expect(
+      document.body.querySelector('[data-slot="dialog-content"]')
+    ).toBeNull();
+  });
+
+  it('should opens and closes through asChild Enter and Space presses', async () => {
+    container = mount(
+      <Dialog>
+        <DialogTrigger asChild>
+          <span>Open dialog</span>
+        </DialogTrigger>
+        <DialogPortal>
+          <DialogContent>
+            Body
+            <DialogClose asChild>
+              <span>Close dialog</span>
+            </DialogClose>
+          </DialogContent>
+        </DialogPortal>
+      </Dialog>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="dialog-trigger"]'
+    ) as HTMLElement;
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="dialog-trigger"]'
+    ) as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    const close = document.body.querySelector(
+      '[data-slot="dialog-close"]'
+    ) as HTMLElement;
+    close.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
     await flushUpdates();
 
     expect(

--- a/tests/browser/components/dropdown/behavior.test.tsx
+++ b/tests/browser/components/dropdown/behavior.test.tsx
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   Dropdown,
   DropdownContent,
@@ -142,6 +143,120 @@ describe('Dropdown - Behavior', () => {
     expect(
       items.every((item) => item.getAttribute('aria-disabled') === 'true')
     ).toBe(true);
+  });
+
+  it('should supports menu-button opening, typeahead, activation, and Tab dismissal', async () => {
+    const onArchiveSelect = vi.fn();
+    container = mount(
+      <div>
+        <Dropdown>
+          <DropdownTrigger>Open database menu</DropdownTrigger>
+          <DropdownPortal>
+            <DropdownContent>
+              <DropdownItem>Alpha</DropdownItem>
+              <DropdownItem textValue="Database1" disabled>
+                Disabled database
+              </DropdownItem>
+              <DropdownItem textValue="Database2">
+                Primary database
+              </DropdownItem>
+              <DropdownItem
+                asChild
+                textValue="Database Archive"
+                onSelect={onArchiveSelect}
+              >
+                <span>Archived database</span>
+              </DropdownItem>
+            </DropdownContent>
+          </DropdownPortal>
+        </Dropdown>
+        <button type="button" data-testid="after-dropdown">
+          After dropdown
+        </button>
+      </div>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="dropdown-trigger"]'
+    ) as HTMLButtonElement;
+    trigger.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await flushUpdates();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="dropdown-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement?.textContent?.trim()).toBe('Alpha');
+
+    await userEvent.keyboard('D');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Primary database'
+    );
+
+    await userEvent.keyboard('d');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Archived database'
+    );
+
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    expect(onArchiveSelect).toHaveBeenCalledTimes(1);
+
+    trigger = container.querySelector(
+      '[data-slot="dropdown-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    trigger.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+    await flushUpdates();
+    trigger = container.querySelector(
+      '[data-slot="dropdown-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    await userEvent.tab();
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="after-dropdown"]')
+    );
+  });
+
+  it('should activates an asChild item with Space', async () => {
+    const onSelect = vi.fn();
+    container = mount(
+      <Dropdown defaultOpen>
+        <DropdownTrigger>Open</DropdownTrigger>
+        <DropdownPortal>
+          <DropdownContent>
+            <DropdownItem asChild onSelect={onSelect}>
+              <span>Archive</span>
+            </DropdownItem>
+          </DropdownContent>
+        </DropdownPortal>
+      </Dropdown>
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    const item = document.body.querySelector(
+      '[data-slot="dropdown-item"]'
+    ) as HTMLElement;
+    item.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const trigger = container.querySelector(
+      '[data-slot="dropdown-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
   it('should throw when DropdownContent is used without Dropdown', () => {

--- a/tests/browser/components/form/a11y.test.tsx
+++ b/tests/browser/components/form/a11y.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it } from 'vite-plus/test';
+import { Form } from '../../../../src/components/form';
+import { expectNoAxeViolations } from '../../accessibility';
+
+describe('Form - Accessibility', () => {
+  it('should have no automated axe violations given labelled controls', async () => {
+    await expectNoAxeViolations(
+      <Form>
+        <label for="account-name">Name</label>
+        <input id="account-name" />
+        <button type="submit">Save</button>
+      </Form>
+    );
+  });
+});

--- a/tests/browser/components/form/determinism.test.tsx
+++ b/tests/browser/components/form/determinism.test.tsx
@@ -1,0 +1,13 @@
+import { describe, it } from 'vite-plus/test';
+import { Form } from '../../../../src/components/form';
+import { expectDeterministicRender } from '../../determinism';
+
+describe('Form - Determinism', () => {
+  it('should render deterministic form markup', () => {
+    expectDeterministicRender(() => (
+      <Form action="/save">
+        <button type="submit">Save</button>
+      </Form>
+    ));
+  });
+});

--- a/tests/browser/components/hover-card/a11y.test.tsx
+++ b/tests/browser/components/hover-card/a11y.test.tsx
@@ -1,0 +1,20 @@
+import { describe, it } from 'vite-plus/test';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '../../../../src/components/hover-card';
+import { expectNoAxeViolations } from '../../accessibility';
+
+describe('HoverCard - Accessibility', () => {
+  it('should have no automated axe violations given interactive content', async () => {
+    await expectNoAxeViolations(
+      <HoverCard defaultOpen>
+        <HoverCardTrigger>Account preview</HoverCardTrigger>
+        <HoverCardContent>
+          <a href="/account">Open account</a>
+        </HoverCardContent>
+      </HoverCard>
+    );
+  });
+});

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -25,7 +25,7 @@ describe('HoverCard - Behavior', () => {
       </HoverCard>
     );
 
-    const trigger = container.querySelector(
+    let trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
 
@@ -95,7 +95,7 @@ describe('HoverCard - Behavior', () => {
         <HoverCardContent>Details</HoverCardContent>
       </HoverCard>
     );
-    const trigger = container.querySelector(
+    let trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
     trigger.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
@@ -113,7 +113,7 @@ describe('HoverCard - Behavior', () => {
       </HoverCard>
     );
     await flushUpdates();
-    const trigger = container.querySelector(
+    let trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
     const content = document.body.querySelector(
@@ -144,5 +144,91 @@ describe('HoverCard - Behavior', () => {
     ) as HTMLElement;
     expect(content.getAttribute('role')).toBe('dialog');
     expect(content.getAttribute('aria-labelledby')).toBe(trigger.id);
+  });
+
+  it('should preserve pointer focus and support Tab, Shift+Tab, and Escape across interactive content', async () => {
+    container = mount(
+      <>
+        <button data-testid="before">Before</button>
+        <HoverCard>
+          <HoverCardTrigger>Preview</HoverCardTrigger>
+          <HoverCardContent>
+            <a href="/first">First</a>
+            <button>Last</button>
+          </HoverCardContent>
+        </HoverCard>
+        <button data-testid="after">After</button>
+      </>
+    );
+    const before = container.querySelector(
+      '[data-testid="before"]'
+    ) as HTMLElement;
+    let trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    before.focus();
+    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await flushUpdates();
+    expect(document.activeElement).toBe(before);
+
+    trigger.focus();
+    await flushUpdates();
+    trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    trigger.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Tab',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    const first = document.body.querySelector(
+      '[data-slot="hover-card-content"] a'
+    ) as HTMLElement;
+    expect(document.activeElement).toBe(first);
+
+    first.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve())
+    );
+    trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.dispatchEvent(new FocusEvent('focus', { bubbles: true }));
+    await flushUpdates();
+    const reopenedFirst = document.body.querySelector(
+      '[data-slot="hover-card-content"] a'
+    ) as HTMLElement;
+    reopenedFirst.focus();
+    reopenedFirst.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => resolve())
+    );
+    trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    expect(document.activeElement).toBe(trigger);
+    expect(
+      document.body.querySelector('[data-slot="hover-card-content"]')
+    ).toBeNull();
   });
 });

--- a/tests/browser/components/hover-card/determinism.test.tsx
+++ b/tests/browser/components/hover-card/determinism.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it } from 'vite-plus/test';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '../../../../src/components/hover-card';
+import { expectDeterministicRender } from '../../determinism';
+
+describe('HoverCard - Determinism', () => {
+  it('should render deterministic trigger markup without scheduling timers', () => {
+    expectDeterministicRender(() => (
+      <HoverCard>
+        <HoverCardTrigger>Account preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    ));
+  });
+});

--- a/tests/browser/components/menu/behavior.test.tsx
+++ b/tests/browser/components/menu/behavior.test.tsx
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   Menu,
   MenuContent,
@@ -51,5 +52,56 @@ describe('Menu - Behavior', () => {
 
     expect(items[0].getAttribute('tabindex')).toBe('0');
     expect(items[1].getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('should supports typeahead, activation keys, and a single Tab stop', async () => {
+    const onArchiveSelect = vi.fn();
+    container = mount(
+      <div>
+        <Menu>
+          <MenuContent>
+            <MenuItem>Alpha</MenuItem>
+            <MenuItem textValue="Database1" disabled>
+              Disabled database
+            </MenuItem>
+            <MenuItem textValue="Database2">Primary database</MenuItem>
+            <MenuItem
+              asChild
+              textValue="Database Archive"
+              onSelect={onArchiveSelect}
+            >
+              <span>Archived database</span>
+            </MenuItem>
+          </MenuContent>
+        </Menu>
+        <button type="button" data-testid="after-menu">
+          After menu
+        </button>
+      </div>
+    );
+
+    const alpha = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent?.trim() === 'Alpha')!;
+    alpha.focus();
+
+    await userEvent.keyboard('D');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Primary database'
+    );
+
+    await userEvent.keyboard('d');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Archived database'
+    );
+
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard(' ');
+    expect(onArchiveSelect).toHaveBeenCalledTimes(2);
+
+    await userEvent.tab();
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="after-menu"]')
+    );
   });
 });

--- a/tests/browser/components/menubar/behavior.test.tsx
+++ b/tests/browser/components/menubar/behavior.test.tsx
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   Menubar,
   MenubarContent,
@@ -117,6 +118,203 @@ describe('Menubar - Behavior', () => {
     );
     await flushPortalUpdates();
     expect(document.body.textContent).not.toContain('New');
+  });
+
+  it('should supports typeahead, activation keys, submenus, and Tab dismissal', async () => {
+    const onArchiveAction = vi.fn();
+    container = mount(
+      <div>
+        <Menubar>
+          <MenubarMenu value="alpha">
+            <MenubarTrigger>Alpha menu</MenubarTrigger>
+            <MenubarPortal>
+              <MenubarContent>
+                <MenubarItem>Alpha action</MenubarItem>
+              </MenubarContent>
+            </MenubarPortal>
+          </MenubarMenu>
+          <MenubarMenu value="database-1">
+            <MenubarTrigger textValue="Database1" disabled>
+              Disabled database menu
+            </MenubarTrigger>
+            <MenubarPortal>
+              <MenubarContent>
+                <MenubarItem>Disabled action</MenubarItem>
+              </MenubarContent>
+            </MenubarPortal>
+          </MenubarMenu>
+          <MenubarMenu value="database-2">
+            <MenubarTrigger textValue="Database2">
+              Primary database menu
+            </MenubarTrigger>
+            <MenubarPortal>
+              <MenubarContent>
+                <MenubarItem>Alpha action</MenubarItem>
+                <MenubarItem textValue="Database1" disabled>
+                  Disabled database action
+                </MenubarItem>
+                <MenubarItem textValue="Database2">
+                  Primary database action
+                </MenubarItem>
+                <MenubarItem
+                  textValue="Database Archive"
+                  onPress={onArchiveAction}
+                >
+                  Archived database action
+                </MenubarItem>
+                <MenubarSub value="tools">
+                  <MenubarSubTrigger textValue="Tools">
+                    Database tools
+                  </MenubarSubTrigger>
+                  <MenubarSubContent>
+                    <MenubarItem>Alpha child action</MenubarItem>
+                    <MenubarItem textValue="Database1" disabled>
+                      Disabled child action
+                    </MenubarItem>
+                    <MenubarItem textValue="Database2">
+                      Primary child action
+                    </MenubarItem>
+                  </MenubarSubContent>
+                </MenubarSub>
+              </MenubarContent>
+            </MenubarPortal>
+          </MenubarMenu>
+          <MenubarMenu value="database-archive">
+            <MenubarTrigger textValue="Database Archive">
+              Archived database menu
+            </MenubarTrigger>
+            <MenubarPortal>
+              <MenubarContent>
+                <MenubarItem>Archive report</MenubarItem>
+              </MenubarContent>
+            </MenubarPortal>
+          </MenubarMenu>
+        </Menubar>
+        <button type="button" data-testid="after-menubar">
+          After menubar
+        </button>
+      </div>
+    );
+    await flushPortalUpdates();
+
+    getButtonByText('Alpha menu').focus();
+
+    await userEvent.keyboard('D');
+    await flushUpdates();
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Primary database menu'
+    );
+
+    await userEvent.keyboard('d');
+    await flushUpdates();
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Archived database menu'
+    );
+
+    await userEvent.keyboard('D');
+    await flushUpdates();
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Primary database menu'
+    );
+
+    await userEvent.keyboard('{Enter}');
+    await flushPortalUpdates();
+    expect(document.activeElement?.textContent?.trim()).toBe('Alpha action');
+
+    await userEvent.keyboard('d');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Primary database action'
+    );
+
+    await userEvent.keyboard('D');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Archived database action'
+    );
+
+    await userEvent.keyboard('{Enter}');
+    await flushPortalUpdates();
+    expect(onArchiveAction).toHaveBeenCalledTimes(1);
+
+    const primaryTrigger = getButtonByText('Primary database menu');
+    primaryTrigger.focus();
+    await userEvent.keyboard(' ');
+    await flushPortalUpdates();
+
+    await userEvent.keyboard('t');
+    expect(document.activeElement?.textContent?.trim()).toBe('Database tools');
+
+    await userEvent.keyboard('{Enter}');
+    await flushPortalUpdates();
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Alpha child action'
+    );
+
+    await userEvent.keyboard('d');
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Primary child action'
+    );
+
+    await userEvent.tab();
+    await flushPortalUpdates();
+
+    expect(
+      getButtonByText('Primary database menu').getAttribute('aria-expanded')
+    ).toBe('false');
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="after-menubar"]')
+    );
+  });
+
+  it('should preserves Enter activation for asChild menu and submenu triggers', async () => {
+    const onFilePress = vi.fn();
+    container = mount(
+      <Menubar>
+        <MenubarMenu value="file">
+          <MenubarTrigger asChild onPress={onFilePress}>
+            <span>File</span>
+          </MenubarTrigger>
+          <MenubarPortal>
+            <MenubarContent>
+              <MenubarSub value="tools">
+                <MenubarSubTrigger asChild>
+                  <span>Tools</span>
+                </MenubarSubTrigger>
+                <MenubarSubContent>
+                  <MenubarItem>Inspect</MenubarItem>
+                </MenubarSubContent>
+              </MenubarSub>
+            </MenubarContent>
+          </MenubarPortal>
+        </MenubarMenu>
+      </Menubar>
+    );
+    await flushPortalUpdates();
+
+    const file = container.querySelector(
+      '[data-slot="menubar-trigger"]'
+    ) as HTMLElement;
+    file.focus();
+    expect(document.activeElement).toBe(file);
+    await userEvent.keyboard('{Enter}');
+    await flushPortalUpdates();
+
+    expect(onFilePress).toHaveBeenCalledTimes(1);
+    expect(
+      container
+        .querySelector('[data-slot="menubar-trigger"]')
+        ?.getAttribute('aria-expanded')
+    ).toBe('true');
+
+    const tools = document.body.querySelector(
+      '[data-slot="menubar-sub-trigger"]'
+    ) as HTMLElement;
+    expect(tools).not.toBeNull();
+
+    tools.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushPortalUpdates();
+
+    expect(document.body.textContent).toContain('Inspect');
   });
 
   it('should position open content without shifting document flow', async () => {

--- a/tests/browser/components/popover/behavior.test.tsx
+++ b/tests/browser/components/popover/behavior.test.tsx
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   Popover,
+  PopoverClose,
   PopoverContent,
   PopoverPortal,
   PopoverTrigger,
@@ -66,6 +68,49 @@ describe('Popover - Behavior', () => {
     expect(content).toBeTruthy();
     expect(trigger?.id).toBeTruthy();
     expect(content?.getAttribute('aria-labelledby')).toBe(trigger?.id);
+  });
+
+  it('should opens and closes through asChild Enter and Space presses', async () => {
+    container = mount(
+      <Popover>
+        <PopoverTrigger asChild>
+          <span>Open popover</span>
+        </PopoverTrigger>
+        <PopoverPortal>
+          <PopoverContent>
+            Details
+            <PopoverClose asChild>
+              <span>Close popover</span>
+            </PopoverClose>
+          </PopoverContent>
+        </PopoverPortal>
+      </Popover>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="popover-trigger"]'
+    ) as HTMLElement;
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="popover-trigger"]'
+    ) as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    const close = document.body.querySelector(
+      '[data-slot="popover-close"]'
+    ) as HTMLElement;
+    close.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(
+      document.body.querySelector('[data-slot="popover-content"]')
+    ).toBeNull();
   });
 
   it('should maps typed width affordance to a stable data attribute', async () => {

--- a/tests/browser/components/radio-group/behavior.test.tsx
+++ b/tests/browser/components/radio-group/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   RadioGroup,
@@ -188,6 +189,40 @@ describe('RadioGroup - Behavior', () => {
     expect(host.getAttribute('data-from-child')).toBe('yes');
     expect(host.getAttribute('aria-checked')).toBe('true');
     expect(host.getAttribute('data-state')).toBe('checked');
+  });
+
+  it('should activates asChild items with Enter and Space', async () => {
+    container = mount(
+      <RadioGroup defaultValue="small">
+        <RadioGroupItem value="small">Small</RadioGroupItem>
+        <RadioGroupItem asChild value="medium">
+          <span>Medium</span>
+        </RadioGroupItem>
+      </RadioGroup>
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    let medium = getRadioByText(container, 'Medium');
+    medium.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    medium = getRadioByText(container, 'Medium');
+    expect(medium.getAttribute('aria-checked')).toBe('true');
+
+    const small = getRadioByText(container, 'Small');
+    small.click();
+    await flushUpdates();
+
+    medium = getRadioByText(container, 'Medium');
+    medium.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+
+    expect(
+      getRadioByText(container, 'Medium').getAttribute('aria-checked')
+    ).toBe('true');
   });
 
   it('should forwards refs to the group container and item hosts', () => {

--- a/tests/browser/components/scroll-area/a11y.test.tsx
+++ b/tests/browser/components/scroll-area/a11y.test.tsx
@@ -1,0 +1,21 @@
+import { describe, it } from 'vite-plus/test';
+import {
+  ScrollArea,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '../../../../src/components/scroll-area';
+import { expectNoAxeViolations } from '../../accessibility';
+
+describe('ScrollArea - Accessibility', () => {
+  it('should have no automated axe violations given a labelled viewport', async () => {
+    await expectNoAxeViolations(
+      <ScrollArea>
+        <ScrollAreaViewport aria-label="Messages">Messages</ScrollAreaViewport>
+        <ScrollAreaScrollbar aria-label="Message position">
+          <ScrollAreaThumb />
+        </ScrollAreaScrollbar>
+      </ScrollArea>
+    );
+  });
+});

--- a/tests/browser/components/scroll-area/behavior.test.tsx
+++ b/tests/browser/components/scroll-area/behavior.test.tsx
@@ -121,4 +121,77 @@ describe('ScrollArea - Behavior', () => {
     expect(ref.current).toBe(viewport);
     expect(onScroll).toHaveBeenCalledOnce();
   });
+
+  it('should synchronize range state and keyboard scrolling given overflow', async () => {
+    container = mount(
+      <>
+        <style>
+          {`[data-testid="metrics-viewport"] {
+            width: 200px;
+            height: 100px;
+            overflow: scroll;
+          }`}
+        </style>
+        <ScrollArea id="metrics">
+          <ScrollAreaViewport data-testid="metrics-viewport">
+            <div style={{ width: '600px', height: '500px' }}>Messages</div>
+          </ScrollAreaViewport>
+          <ScrollAreaScrollbar orientation="vertical">
+            <ScrollAreaThumb />
+          </ScrollAreaScrollbar>
+          <ScrollAreaScrollbar orientation="horizontal">
+            <ScrollAreaThumb />
+          </ScrollAreaScrollbar>
+        </ScrollArea>
+      </>
+    );
+    await flushUpdates();
+    const viewport = container.querySelector(
+      '[data-slot="scroll-area-viewport"]'
+    ) as HTMLElement;
+    viewport.dispatchEvent(new Event('scroll', { bubbles: true }));
+    await flushUpdates();
+    let bars = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-slot="scroll-area-scrollbar"]'
+      )
+    );
+    expect(bars[0]?.id).not.toBe(bars[1]?.id);
+    expect(bars[0]?.getAttribute('aria-valuemin')).toBe('0');
+    expect(bars[0]?.getAttribute('aria-valuemax')).toBe('100');
+    expect(bars[0]?.getAttribute('aria-valuenow')).toBe('0');
+    expect(bars[0]?.tabIndex).toBe(0);
+
+    bars[0]?.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    bars = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-slot="scroll-area-scrollbar"]'
+      )
+    );
+    expect(viewport.scrollTop).toBeCloseTo(40, 0);
+    expect(bars[0]?.getAttribute('aria-valuenow')).toBe('10');
+
+    bars[0]?.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'End',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    bars = Array.from(
+      container.querySelectorAll<HTMLElement>(
+        '[data-slot="scroll-area-scrollbar"]'
+      )
+    );
+    expect(viewport.scrollTop).toBe(400);
+    expect(bars[0]?.getAttribute('aria-valuenow')).toBe('100');
+  });
 });

--- a/tests/browser/components/scroll-area/determinism.test.tsx
+++ b/tests/browser/components/scroll-area/determinism.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it } from 'vite-plus/test';
+import {
+  ScrollArea,
+  ScrollAreaScrollbar,
+  ScrollAreaThumb,
+  ScrollAreaViewport,
+} from '../../../../src/components/scroll-area';
+import { expectDeterministicRender } from '../../determinism';
+
+describe('ScrollArea - Determinism', () => {
+  it('should render deterministic IDs and range markup', () => {
+    expectDeterministicRender(() => (
+      <ScrollArea id="messages">
+        <ScrollAreaViewport>Messages</ScrollAreaViewport>
+        <ScrollAreaScrollbar orientation="vertical">
+          <ScrollAreaThumb />
+        </ScrollAreaScrollbar>
+        <ScrollAreaScrollbar orientation="horizontal">
+          <ScrollAreaThumb />
+        </ScrollAreaScrollbar>
+      </ScrollArea>
+    ));
+  });
+});

--- a/tests/browser/components/select/behavior.test.tsx
+++ b/tests/browser/components/select/behavior.test.tsx
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   Select,
   SelectContent,
@@ -16,6 +17,7 @@ describe('Select - Behavior', () => {
   let container: HTMLElement;
 
   afterEach(() => {
+    vi.useRealTimers();
     unmount(container);
   });
 
@@ -276,6 +278,286 @@ describe('Select - Behavior', () => {
     expect(items.every((item) => item.getAttribute('tabindex') === '-1')).toBe(
       true
     );
+  });
+
+  it('should supports buffered typeahead from the trigger and listbox focus', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <Select name="database" defaultValue="alpha">
+        <SelectTrigger>
+          <SelectValue placeholder="Choose one" />
+        </SelectTrigger>
+        <SelectPortal>
+          <SelectContent tabIndex={0}>
+            <SelectItem value="alpha">Alpha</SelectItem>
+            <SelectItem value="database-1" textValue="Database1" disabled>
+              Disabled database
+            </SelectItem>
+            <SelectItem value="database-2" textValue="Database2">
+              Primary database
+            </SelectItem>
+            <SelectItem value="database-archive" textValue="Database Archive">
+              Archived database
+            </SelectItem>
+            <SelectItem value="delta">Delta</SelectItem>
+          </SelectContent>
+        </SelectPortal>
+      </Select>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    trigger.focus();
+
+    for (const key of 'database2') {
+      trigger = container.querySelector(
+        '[data-slot="select-trigger"]'
+      ) as HTMLButtonElement;
+      trigger.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await flushUpdates();
+    }
+
+    expect(
+      (container.querySelector('input[name="database"]') as HTMLInputElement)
+        .value
+    ).toBe('database-2');
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.click();
+    await flushUpdates();
+    await flushUpdates();
+
+    let content = document.body.querySelector(
+      '[data-slot="select-content"]'
+    ) as HTMLElement;
+    content.focus();
+
+    const firstD = new KeyboardEvent('keydown', {
+      key: 'D',
+      bubbles: true,
+      cancelable: true,
+    });
+    content.dispatchEvent(firstD);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(firstD.defaultPrevented).toBe(true);
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Archived database'
+    );
+
+    content = document.body.querySelector(
+      '[data-slot="select-content"]'
+    ) as HTMLElement;
+    content.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'd',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement?.textContent?.trim()).toBe('Delta');
+
+    await vi.advanceTimersByTimeAsync(600);
+    content = document.body.querySelector(
+      '[data-slot="select-content"]'
+    ) as HTMLElement;
+    content.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'a',
+        bubbles: true,
+        cancelable: true,
+      })
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement?.textContent?.trim()).toBe('Alpha');
+
+    await vi.advanceTimersByTimeAsync(600);
+    for (const key of 'database archive') {
+      const target = document.activeElement as HTMLElement;
+      target.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await flushUpdates();
+      (document.activeElement as HTMLElement).dispatchEvent(
+        new KeyboardEvent('keyup', {
+          key,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+      await flushUpdates();
+    }
+
+    expect(document.activeElement?.textContent?.trim()).toBe(
+      'Archived database'
+    );
+  });
+
+  it('should keeps arrow, Space, Enter, and Tab interactions intuitive', async () => {
+    container = mount(
+      <div>
+        <Select name="framework" defaultValue="alpha">
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectContent>
+              <SelectItem value="alpha">Alpha</SelectItem>
+              <SelectItem asChild value="beta">
+                <span>Beta</span>
+              </SelectItem>
+            </SelectContent>
+          </SelectPortal>
+        </Select>
+        <button type="button" data-testid="after-select">
+          After select
+        </button>
+      </div>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    trigger.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await flushUpdates();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement?.textContent?.trim()).toBe('Alpha');
+
+    await userEvent.keyboard('{ArrowDown}');
+    await flushUpdates();
+    await flushUpdates();
+    expect(document.activeElement?.textContent?.trim()).toBe('Beta');
+
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    expect(
+      (container.querySelector('input[name="framework"]') as HTMLInputElement)
+        .value
+    ).toBe('beta');
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    await flushUpdates();
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    await flushUpdates();
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should opens with Space and moves past the popup with Tab', async () => {
+    container = mount(
+      <div>
+        <Select defaultValue="alpha">
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectContent>
+              <SelectItem value="alpha">Alpha</SelectItem>
+              <SelectItem value="beta">Beta</SelectItem>
+            </SelectContent>
+          </SelectPortal>
+        </Select>
+        <button type="button" data-testid="after-select">
+          After select
+        </button>
+      </div>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    trigger.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+    await flushUpdates();
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    await userEvent.tab();
+    await flushUpdates();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLButtonElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(document.activeElement).toBe(
+      container.querySelector('[data-testid="after-select"]')
+    );
+  });
+
+  it('should opens an asChild trigger with Enter', async () => {
+    container = mount(
+      <Select defaultValue="alpha">
+        <SelectTrigger asChild>
+          <span>
+            <SelectValue />
+          </span>
+        </SelectTrigger>
+        <SelectPortal>
+          <SelectContent>
+            <SelectItem value="alpha">Alpha</SelectItem>
+          </SelectContent>
+        </SelectPortal>
+      </Select>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLElement;
+    trigger.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="select-trigger"]'
+    ) as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement?.textContent?.trim()).toBe('Alpha');
   });
 
   it('should throw when SelectContent is used without Select', () => {

--- a/tests/browser/components/switch/behavior.test.tsx
+++ b/tests/browser/components/switch/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { Switch } from '../../../../src/components/switch/switch';
 import { mount, unmount } from '../../test-utils';
@@ -146,6 +147,31 @@ describe('Switch - Behavior', () => {
     expect(host?.getAttribute('role')).toBe('switch');
     expect(host?.getAttribute('aria-checked')).toBe('true');
     expect(host?.getAttribute('data-state')).toBe('checked');
+  });
+
+  it('should toggles an asChild host with Enter and Space', async () => {
+    const onCheckedChange = vi.fn();
+    container = mount(
+      <Switch asChild onCheckedChange={onCheckedChange}>
+        <span>Power</span>
+      </Switch>
+    );
+
+    let host = container.querySelector('[role="switch"]') as HTMLElement;
+    host.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+
+    host = container.querySelector('[role="switch"]') as HTMLElement;
+    expect(host.getAttribute('aria-checked')).toBe('true');
+
+    host.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    host = container.querySelector('[role="switch"]') as HTMLElement;
+    expect(host.getAttribute('aria-checked')).toBe('false');
+    expect(onCheckedChange.mock.calls).toEqual([[true], [false]]);
   });
 
   it('should applies disabled semantics to asChild hosts', () => {

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { state } from '@askrjs/askr';
 import { Portal } from '@askrjs/askr/foundations';
 import { Link } from '@askrjs/askr/router';
@@ -349,6 +350,51 @@ describe('Toast - Behavior', () => {
       '[data-toast-action="true"]'
     ) as HTMLButtonElement;
     action.click();
+    await flushUpdates();
+    expect(container.querySelector('[data-toast="true"]')).toBeNull();
+  });
+
+  it('should dismisses asChild actions and close controls with Enter and Space', async () => {
+    container = mount(
+      <ToastHost duration={60_000}>
+        <ToastViewport />
+        <Toast defaultOpen>
+          <ToastTitle>Action toast</ToastTitle>
+          <ToastAction asChild>
+            <span>Undo</span>
+          </ToastAction>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+
+    const action = container.querySelector(
+      '[data-toast-action="true"]'
+    ) as HTMLElement;
+    action.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+    expect(container.querySelector('[data-toast="true"]')).toBeNull();
+
+    unmount(container);
+    container = mount(
+      <ToastHost duration={60_000}>
+        <ToastViewport />
+        <Toast defaultOpen>
+          <ToastTitle>Close toast</ToastTitle>
+          <ToastClose asChild>
+            <span>Dismiss</span>
+          </ToastClose>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+
+    const close = container.querySelector(
+      '[data-toast-close="true"]'
+    ) as HTMLElement;
+    close.focus();
+    await userEvent.keyboard(' ');
     await flushUpdates();
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });

--- a/tests/browser/components/toggle-group/behavior.test.tsx
+++ b/tests/browser/components/toggle-group/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 import { For } from '@askrjs/askr';
 import {
@@ -332,6 +333,33 @@ describe('ToggleGroup - Behavior', () => {
     expect(host.getAttribute('data-from-child')).toBe('yes');
     expect(host.getAttribute('aria-pressed')).toBe('true');
     expect(host.getAttribute('data-state')).toBe('on');
+  });
+
+  it('should toggles an asChild item with Enter and Space', async () => {
+    container = mount(
+      <ToggleGroup>
+        <ToggleGroupItem asChild value="left">
+          <span>Left</span>
+        </ToggleGroupItem>
+      </ToggleGroup>
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    let item = getToggleByText(container, 'Left');
+    item.focus();
+    await userEvent.keyboard('{Enter}');
+    await flushUpdates();
+
+    item = getToggleByText(container, 'Left');
+    expect(item.getAttribute('aria-pressed')).toBe('true');
+
+    item.focus();
+    await userEvent.keyboard(' ');
+    await flushUpdates();
+
+    item = getToggleByText(container, 'Left');
+    expect(item.getAttribute('aria-pressed')).toBe('false');
   });
 
   it('should forwards refs to the group container and item hosts', () => {

--- a/tests/browser/components/toggle/behavior.test.tsx
+++ b/tests/browser/components/toggle/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { describe, it, expect, vi, afterEach } from 'vite-plus/test';
 import { Toggle } from '../../../../src/components/toggle/toggle';
 import { mount, unmount } from '../../test-utils';
@@ -109,6 +110,23 @@ describe('Toggle - Behavior', () => {
     host?.click();
 
     expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('should activates an asChild host with Enter and Space', async () => {
+    const onPress = vi.fn();
+    container = mount(
+      <Toggle asChild onPress={onPress}>
+        <span>Mute</span>
+      </Toggle>
+    );
+
+    const host = container.querySelector('[role="button"]') as HTMLElement;
+    host.focus();
+    await userEvent.keyboard('{Enter}');
+    host.focus();
+    await userEvent.keyboard(' ');
+
+    expect(onPress).toHaveBeenCalledTimes(2);
   });
 
   it('should applies disabled semantics to asChild hosts', () => {

--- a/tests/unit/docs-contract.test.ts
+++ b/tests/unit/docs-contract.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 import * as askrUi from '../../src';
 import {
+  componentSurface,
   publicValueExports,
   removedPublicExports,
 } from './fixtures/public-surface';
@@ -115,6 +116,40 @@ describe('Docs contract', () => {
       expect(
         symbol in askrUi,
         `Published export is missing from package surface: ${symbol}`
+      ).toBe(true);
+    }
+  });
+
+  it('should only list public component families in the conceptual groupings', () => {
+    const docs = readFileSync(
+      join(process.cwd(), 'docs', 'components.md'),
+      'utf8'
+    );
+    const grouping = docs.match(
+      /## Conceptual groupings([\s\S]*?)## Family notes/
+    )?.[1];
+    expect(grouping).toBeTruthy();
+    const documentedFamilies = Array.from(
+      grouping!.matchAll(/^\|[^|]+\|([^|]+)\|$/gm),
+      (match) => match[1]
+    )
+      .flatMap((cell) => cell.split(','))
+      .map((name) =>
+        name
+          .trim()
+          .replace(/([a-z])([A-Z])/g, '$1-$2')
+          .toLowerCase()
+          .replaceAll(' ', '-')
+      )
+      .filter(
+        (name) =>
+          name.length > 0 && name !== 'families' && !name.startsWith('---')
+      );
+    const publicFamilies = new Set(componentSurface.map(({ name }) => name));
+    for (const family of documentedFamilies) {
+      expect(
+        publicFamilies.has(family as never),
+        `Documented family is not public: ${family}`
       ).toBe(true);
     }
   });

--- a/tests/unit/types/public-api.type-test.ts
+++ b/tests/unit/types/public-api.type-test.ts
@@ -374,10 +374,14 @@ const menuContentAsChildProps: MenuContentAsChildProps = {
   asChild: true,
   children: slotChild,
 };
-const menuItemProps: MenuItemProps = { children: 'Menu item' };
+const menuItemProps: MenuItemProps = {
+  children: 'Menu item',
+  textValue: 'Menu item',
+};
 const menuItemAsChildProps: MenuItemAsChildProps = {
   asChild: true,
   children: slotChild,
+  textValue: 'Menu item',
 };
 
 const dropdownContentProps: DropdownContentProps = {};
@@ -401,11 +405,13 @@ const dropdownTriggerAsChildProps: DropdownTriggerAsChildProps = {
 const dropdownItemVariant: DropdownItemVariant = 'destructive';
 const dropdownItemProps: DropdownItemProps = {
   children: 'Action',
+  textValue: 'Action',
   variant: dropdownItemVariant,
 };
 const dropdownItemAsChildProps: DropdownItemAsChildProps = {
   asChild: true,
   children: slotChild,
+  textValue: 'Action',
   variant: 'destructive',
 };
 
@@ -436,11 +442,13 @@ const selectContentAsChildProps: SelectContentAsChildProps = {
 const selectItemProps: SelectItemProps = {
   value: 'one',
   children: 'One',
+  textValue: 'One',
 };
 const selectItemAsChildProps: SelectItemAsChildProps = {
   asChild: true,
   value: 'one',
   children: slotChild,
+  textValue: 'One',
 };
 
 const _invalidButtonAsChild: ButtonAsChildProps = {

--- a/tests/unit/types/public-components.type-test.ts
+++ b/tests/unit/types/public-components.type-test.ts
@@ -19,6 +19,7 @@ import {
   MenubarItem,
   MenubarMenu,
   MenubarPortal,
+  MenubarSubTrigger,
   MenubarTrigger,
   Progress,
   ProgressCircle,
@@ -58,6 +59,8 @@ import {
   type MenubarItemProps,
   type MenubarMenuProps,
   type MenubarProps,
+  type MenubarSubTriggerAsChildProps,
+  type MenubarSubTriggerProps,
   type MenubarTriggerAsChildProps,
   type MenubarTriggerProps,
   type ProgressCircleProps,
@@ -141,20 +144,37 @@ const tableHeaderCellProps: TableHeaderCellProps = { children: 'name' };
 const tableCellProps: TableCellProps = { children: 'Alice' };
 const menubarProps: MenubarProps = { children: 'menu' };
 const menubarMenuProps: MenubarMenuProps = { children: 'menu' };
-const menubarTriggerProps: MenubarTriggerProps = { children: 'File' };
+const menubarTriggerProps: MenubarTriggerProps = {
+  children: 'File',
+  textValue: 'File',
+};
 const menubarTriggerAsChildProps: MenubarTriggerAsChildProps = {
   asChild: true,
   children: slotChild,
+  textValue: 'File',
 };
 const menubarContentProps: MenubarContentProps = { children: 'Panel' };
 const menubarContentAsChildProps: MenubarContentAsChildProps = {
   asChild: true,
   children: slotChild,
 };
-const menubarItemProps: MenubarItemProps = { children: 'Item' };
+const menubarItemProps: MenubarItemProps = {
+  children: 'Item',
+  textValue: 'Item',
+};
 const menubarItemAsChildProps: MenubarItemAsChildProps = {
   asChild: true,
   children: slotChild,
+  textValue: 'Item',
+};
+const menubarSubTriggerProps: MenubarSubTriggerProps = {
+  children: 'Recent',
+  textValue: 'Recent',
+};
+const menubarSubTriggerAsChildProps: MenubarSubTriggerAsChildProps = {
+  asChild: true,
+  children: slotChild,
+  textValue: 'Recent',
 };
 const accordionSingleProps: AccordionSingleProps = { defaultValue: 'a' };
 const accordionMultipleProps: AccordionMultipleProps = {
@@ -253,6 +273,7 @@ void [
   MenubarPortal,
   MenubarContent,
   MenubarItem,
+  MenubarSubTrigger,
   CollapsibleTrigger,
   CollapsibleContent,
   ProgressIndicator,
@@ -298,6 +319,8 @@ void [
   menubarContentAsChildProps,
   menubarItemProps,
   menubarItemAsChildProps,
+  menubarSubTriggerProps,
+  menubarSubTriggerAsChildProps,
   accordionSingleProps,
   accordionMultipleProps,
   accordionTriggerProps,


### PR DESCRIPTION
## Summary

- unify press cancellation, composite focus traversal, typeahead, and live collection behavior across interactive component families
- harden HoverCard, ScrollArea, Menu, Menubar, Dropdown, Select, and related keyboard/accessibility behavior
- add browser behavior, accessibility, determinism, public-type, documentation, packaging, and benchmark coverage

## Validation

- `npm ci`
- `npm run fmt`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test` (306 browser files / 1,197 browser tests across Chromium, Firefox, and WebKit)
- `npm run test:publint`
- `npm run pack:check` (1,199 packed files plus isolated ESM/types consumers)
- `npm run bench` (tiers 1-4)
- `git diff --check`
