### PR TITLE
chore(release): prepare @askrjs/ui 0.0.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.1.0",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.1.0",
+      "version": "0.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.75 <0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.22",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.22",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.75 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.22",
+  "version": "0.1.0",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.1.0",
+  "version": "0.0.23",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",


### PR DESCRIPTION
## Summary

- bump `@askrjs/ui` from `0.0.22` to `0.0.23`
- ship the merged keyboard, accessibility, typeahead, packaging, and public `textValue` hardening as the next pre-1.0 patch

## Validation

- `npm run check`
  - 306 browser files / 1,197 browser tests across Chromium, Firefox, and WebKit
  - publint
  - 1,199-file packed artifact plus isolated ESM/types consumers
- `npm run fmt -- --check`
- `git diff --check`
