### PR TITLE
chore(release): prepare @askrjs/ui 0.0.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.85 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",


### PR DESCRIPTION
## Summary
- bump `@askrjs/ui` from 0.0.23 to 0.0.24
- publish the component-owned Toast lifecycle and focus-restoration fix from #34
- publish the collection ownership, overlay focus, HoverCard throttling, and core-contract hardening from #36
- require registry `@askrjs/askr@0.0.85` and Node `>=24.15.0`

## Verification
- `npm ci`
- `npm audit` — 0 vulnerabilities
- `npm run fmt -- --check`
- `npm run check`
- 1,206 browser tests passed in 306 files
- packed artifact validated 1,199 files and isolated ESM/types

Release only; publication occurs only after this exact head is green, reviewed, and merged.
