### PR TITLE
chore: require Node 24 and npm 12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.1.0",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.1.0",
+      "version": "0.0.23",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.75 <0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.22",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.22",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.75 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.22",
+  "version": "0.1.0",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
     "@askrjs/askr": ">=0.0.75 <0.1.0"
   },
   "engines": {
-    "node": ">=18"
-  }
+    "node": ">=24.0.0"
+  },
+  "packageManager": "npm@12.0.1"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.1.0",
+  "version": "0.0.23",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",


### PR DESCRIPTION
Standardizes the package metadata on Node 24 and npm 12:

- Sets `engines.node` to `>=24.0.0`.
- Pins the package manager to `npm@12.0.1`.

This keeps the package contract aligned with the current Node LTS CI policy.