### PR TITLE
chore: release v0.0.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.85 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",


### PR DESCRIPTION
Release v0.0.25 with the Node.js 24 and npm 12 package metadata updates.