### PR TITLE
docs: publish UI capability manifest

### DIFF
--- a/capabilities.json
+++ b/capabilities.json
@@ -28,12 +28,8 @@
       "intent": "focused accessibility and interaction primitives",
       "package": "@askrjs/ui",
       "import": "@askrjs/ui/focus-scope",
-      "exports": [
-        "FocusScope"
-      ],
-      "constraints": [
-        "focus behavior is scoped to the mounted subtree"
-      ],
+      "exports": ["FocusScope"],
+      "constraints": ["focus behavior is scoped to the mounted subtree"],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-ui/blob/main/README.md",
       "docsPath": "README.md"

--- a/capabilities.json
+++ b/capabilities.json
@@ -6,8 +6,20 @@
       "intent": "headless accessible component primitives",
       "package": "@askrjs/ui",
       "import": "@askrjs/ui",
-      "exports": ["Button", "Dialog", "Popover", "Menu", "Table", "Select", "Tabs", "Tooltip"],
-      "constraints": ["components provide behavior and accessibility semantics", "styles are consumer-owned"],
+      "exports": [
+        "Button",
+        "Dialog",
+        "Popover",
+        "Menu",
+        "Table",
+        "Select",
+        "Tabs",
+        "Tooltip"
+      ],
+      "constraints": [
+        "components provide behavior and accessibility semantics",
+        "styles are consumer-owned"
+      ],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-ui/blob/main/README.md",
       "docsPath": "README.md"
@@ -16,8 +28,12 @@
       "intent": "focused accessibility and interaction primitives",
       "package": "@askrjs/ui",
       "import": "@askrjs/ui/focus-scope",
-      "exports": ["FocusScope"],
-      "constraints": ["focus behavior is scoped to the mounted subtree"],
+      "exports": [
+        "FocusScope"
+      ],
+      "constraints": [
+        "focus behavior is scoped to the mounted subtree"
+      ],
       "stability": "stable",
       "docs": "https://github.com/askrjs/askr-ui/blob/main/README.md",
       "docsPath": "README.md"

--- a/capabilities.json
+++ b/capabilities.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "package": "@askrjs/ui",
+  "capabilities": [
+    {
+      "intent": "headless accessible component primitives",
+      "package": "@askrjs/ui",
+      "import": "@askrjs/ui",
+      "exports": ["Button", "Dialog", "Popover", "Menu", "Table", "Select", "Tabs", "Tooltip"],
+      "constraints": ["components provide behavior and accessibility semantics", "styles are consumer-owned"],
+      "stability": "stable",
+      "docs": "https://github.com/askrjs/askr-ui/blob/main/README.md",
+      "docsPath": "README.md"
+    },
+    {
+      "intent": "focused accessibility and interaction primitives",
+      "package": "@askrjs/ui",
+      "import": "@askrjs/ui/focus-scope",
+      "exports": ["FocusScope"],
+      "constraints": ["focus behavior is scoped to the mounted subtree"],
+      "stability": "stable",
+      "docs": "https://github.com/askrjs/askr-ui/blob/main/README.md",
+      "docsPath": "README.md"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -206,8 +206,7 @@
       "import": "./dist/components/tooltip/index.js",
       "require": "./dist/components/tooltip/index.cjs"
     },
-    "./package.json": "./package.json",
-    "./capabilities.json": "./capabilities.json"
+    "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "url": "git+https://github.com/askrjs/askr-ui.git"
   },
   "files": [
-    "dist"
+    "dist",
+    "capabilities.json"
   ],
   "type": "module",
   "sideEffects": false,
@@ -205,7 +206,8 @@
       "import": "./dist/components/tooltip/index.js",
       "require": "./dist/components/tooltip/index.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./capabilities.json": "./capabilities.json"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Closes #42. Adds and publishes capabilities.json for headless primitives and focus behavior.

Validation: JSON/package metadata validation.