### PR TITLE
chore: release v0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.85 <0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.26",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@askrjs/askr": ">=0.0.87 <0.1.0",
+        "@askrjs/askr": ">=0.0.88 <0.1.0",
         "@askrjs/vite": ">=0.0.12 <0.1.0",
         "@types/node": "^26.1.2",
         "@vitest/browser-playwright": "4.1.10",
@@ -26,7 +26,7 @@
         "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "@askrjs/askr": ">=0.0.87 <0.1.0"
+        "@askrjs/askr": ">=0.0.88 <0.1.0"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -63,27 +63,32 @@
       }
     },
     "node_modules/@askrjs/askr": {
-      "version": "0.0.87",
-      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.87.tgz",
-      "integrity": "sha512-pfZ5s2z/MW0gHtM43dvnCqDF/0DBOYF2eeEE0B9YgBWN4Hljv89CHfpZf/d2TvHy1KIxNiR4DoAZs1g3212P4g==",
+      "version": "0.0.88",
+      "resolved": "https://registry.npmjs.org/@askrjs/askr/-/askr-0.0.88.tgz",
+      "integrity": "sha512-+LoZmOqTl6x3XENgKwYyXZQtgHMVw/rTitJ5VfjBmwU6EtkDz1XzZInb+fdDS+fVoobYyw1gc2PC933wodACNQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@askrjs/auth": ">=0.0.1 <0.1.0",
-        "@askrjs/schema": ">=0.0.1 <0.1.0"
+        "@askrjs/auth": ">=0.0.8 <0.1.0",
+        "@askrjs/schema": ">=0.0.5 <0.1.0"
       },
       "engines": {
         "node": ">=24.0.0"
       }
     },
     "node_modules/@askrjs/auth": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@askrjs/auth/-/auth-0.0.2.tgz",
-      "integrity": "sha512-Air+kUS+TEXcWW46/EItPnKbTfNgeklf7C7HqyM+xrX8ZqLAbQ3wD5hFNoqiWY/Ansh3cdkFbJpIumCKgCre8w==",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@askrjs/auth/-/auth-0.0.8.tgz",
+      "integrity": "sha512-0Lg2fvD21LIi1C8ZelC8tUZr6XBNW2DQil9HRuUqedc4TRNJqsqizH3nXB+sTyYLjbIj0lqZmdI2LBzmPsYMHA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.8.13",
+        "xml-crypto": "6.1.2",
+        "xml-encryption": "5.0.0"
+      },
       "engines": {
-        "node": ">=18"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@askrjs/node": {
@@ -102,13 +107,13 @@
       }
     },
     "node_modules/@askrjs/schema": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@askrjs/schema/-/schema-0.0.2.tgz",
-      "integrity": "sha512-7+ebvThTogzigk5++Yg7smERo9nWe+KjAohr+jsLoQ+70JHgLy+FPTLnho0THnw/mJSx4RtFjOjCUHHUELI7Dw==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@askrjs/schema/-/schema-0.0.5.tgz",
+      "integrity": "sha512-E0dUDc/ceGPZBi+ShyZuutQ1o8gvYJ8H6/d8yAqPsnRCFRJfglYYTXivw8ySWDRlJrPOL01hZmuiuYQdE9NHkg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@askrjs/server": {
@@ -2507,6 +2512,26 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@xmldom/is-dom-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@yuku-codegen/binding-darwin-arm64": {
       "version": "0.5.48",
       "resolved": "https://registry.npmjs.org/@yuku-codegen/binding-darwin-arm64/-/binding-darwin-arm64-0.5.48.tgz",
@@ -3015,6 +3040,13 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true,
       "license": "MIT"
     },
@@ -4507,6 +4539,43 @@
         }
       }
     },
+    "node_modules/xml-crypto": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
+      "integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "xpath": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/xml-encryption": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-5.0.0.tgz",
+      "integrity": "sha512-9XUEdUcXiim15WsQ37P+z0CD3uTytLoWoGL/PhRqA5ZqmDhKMtiyMJcn1pT1+kBBtCTSqBaiPs+ILdiD7nQuQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.13",
+        "escape-html": "^1.0.3",
+        "xpath": "0.0.32"
+      }
+    },
+    "node_modules/xml-encryption/node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -4523,6 +4592,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xpath": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
     "node_modules/yuku-codegen": {
       "version": "0.5.48",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/package.json
+++ b/package.json
@@ -237,7 +237,7 @@
     "test:checks": "vp test run -c vitest.test.checks.config.ts"
   },
   "devDependencies": {
-    "@askrjs/askr": ">=0.0.87 <0.1.0",
+    "@askrjs/askr": ">=0.0.88 <0.1.0",
     "@askrjs/vite": ">=0.0.12 <0.1.0",
     "@types/node": "^26.1.2",
     "@vitest/browser-playwright": "4.1.10",
@@ -251,7 +251,7 @@
     "vite-plus": "^0.2.8"
   },
   "peerDependencies": {
-    "@askrjs/askr": ">=0.0.87 <0.1.0"
+    "@askrjs/askr": ">=0.0.88 <0.1.0"
   },
   "engines": {
     "node": ">=24.0.0"


### PR DESCRIPTION
Patch release. Local gate is blocked by reproducible Select typeahead browser failures in Chromium, Firefox, and WebKit; do not merge until fixed.