### PR TITLE
fix: preserve false ARIA props on Button

### DIFF
--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -3,6 +3,18 @@ import { mergeProps } from '@askrjs/askr/foundations/utilities';
 import { getButtonInteractionProps } from './button-interactions';
 import type { ButtonNativeProps, ButtonAsChildProps } from './button.types';
 
+function normalizeAriaProps(
+  props: Record<string, unknown>
+): Record<string, unknown> {
+  const normalized = { ...props };
+  for (const key of Object.keys(normalized)) {
+    if (key.startsWith('aria-') && typeof normalized[key] === 'boolean') {
+      normalized[key] = String(normalized[key]);
+    }
+  }
+  return normalized;
+}
+
 /**
  * Headless Button component
  *
@@ -64,7 +76,7 @@ export function Button(props: ButtonNativeProps | ButtonAsChildProps) {
   });
 
   // Prop composition: merge user props, interaction props, and ref
-  const finalProps = mergeProps(rest, {
+  const finalProps = mergeProps(normalizeAriaProps(rest), {
     ...interactionProps,
     'data-slot': 'button',
     'data-disabled': disabled ? 'true' : undefined,

--- a/tests/jsdom/components/button/jsdom.test.tsx
+++ b/tests/jsdom/components/button/jsdom.test.tsx
@@ -75,4 +75,12 @@ describe('Button - jsdom regression', () => {
   it('should replaces a stateful icon child instead of accumulating icons in dist', async () => {
     await expectSingleIconAcrossToggles(DistButton);
   });
+
+  it('should preserve explicit false ARIA state', async () => {
+    container = mount(<Button aria-expanded={false}>Search</Button>);
+
+    expect(
+      container.querySelector('button')?.getAttribute('aria-expanded')
+    ).toBe('false');
+  });
 });


### PR DESCRIPTION
Related to askr-themes#53

## Summary
- normalize boolean `aria-*` props before Button forwarding
- add a jsdom regression for `aria-expanded={false}`

## Validation
- focused Button jsdom suite: passed