### PR TITLE
chore: refresh node types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",
         "@askrjs/vite": ">=0.0.12 <0.1.0",
-        "@types/node": "^26.1.2",
+        "@types/node": "^26.2.0",
         "@vitest/browser-playwright": "4.1.10",
         "axe-core": "^4.13.0",
         "cross-env": "^10.1.0",
@@ -1711,9 +1711,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
-      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -239,7 +239,7 @@
   "devDependencies": {
     "@askrjs/askr": ">=0.0.88 <0.1.0",
     "@askrjs/vite": ">=0.0.12 <0.1.0",
-    "@types/node": "^26.1.2",
+    "@types/node": "^26.2.0",
     "@vitest/browser-playwright": "4.1.10",
     "axe-core": "^4.13.0",
     "cross-env": "^10.1.0",

--- a/tests/browser/components/accordion/behavior.test.tsx
+++ b/tests/browser/components/accordion/behavior.test.tsx
@@ -32,7 +32,7 @@ describe('Accordion - Behavior', () => {
     unmount(container);
   });
 
-  it('should mounts single and multiple accordions without render-time state errors', () => {
+  it('should mount single and multiple accordions without render-time state errors', () => {
     expect(() => {
       container = mount(
         <div>
@@ -157,7 +157,7 @@ describe('Accordion - Behavior', () => {
     ).toHaveLength(2);
   });
 
-  it('should activates an asChild trigger with Enter and Space', async () => {
+  it('should activate an asChild trigger with Enter and Space', async () => {
     container = mount(
       <Accordion collapsible>
         <AccordionItem value="details">

--- a/tests/browser/components/alert-dialog/behavior.test.tsx
+++ b/tests/browser/components/alert-dialog/behavior.test.tsx
@@ -18,7 +18,7 @@ describe('AlertDialog - Behavior', () => {
     unmount(container);
   });
 
-  it('should keeps trigger expansion state open after re-activation', async () => {
+  it('should keep trigger expansion state open after re-activation', async () => {
     container = mount(
       <AlertDialog>
         <AlertDialogTrigger>Open alert</AlertDialogTrigger>
@@ -45,7 +45,7 @@ describe('AlertDialog - Behavior', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('should preserves button styling props when composed controls are children', async () => {
+  it('should preserve button styling props when composed controls are children', async () => {
     container = mount(
       <AlertDialog>
         <Button asChild variant="destructive">
@@ -94,7 +94,7 @@ describe('AlertDialog - Behavior', () => {
     ).toBeNull();
   });
 
-  it('should forwards dismiss callbacks from alert dialog content', async () => {
+  it('should forward dismiss callbacks from alert dialog content', async () => {
     const onDismiss = vi.fn();
 
     container = mount(
@@ -126,7 +126,7 @@ describe('AlertDialog - Behavior', () => {
     ).toBeNull();
   });
 
-  it('should keeps centered alert dialog content within viewport padding on narrow viewports', async () => {
+  it('should keep centered alert dialog content within viewport padding on narrow viewports', async () => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
       (callback: FrameRequestCallback) => {
         callback(0);

--- a/tests/browser/components/button/a11y.test.tsx
+++ b/tests/browser/components/button/a11y.test.tsx
@@ -21,11 +21,11 @@ function unmount(container: HTMLElement) {
 }
 
 describe('Button - Accessibility', () => {
-  it('should has no automated axe violations for the native button path', async () => {
+  it('should have no automated axe violations for the native button path', async () => {
     await expectNoAxeViolations(<Button>Save</Button>);
   });
 
-  it('should has no automated axe violations for labelled asChild composition', async () => {
+  it('should have no automated axe violations for labelled asChild composition', async () => {
     await expectNoAxeViolations(
       <Button asChild>
         <a href="/docs" aria-label="Read documentation">
@@ -35,7 +35,7 @@ describe('Button - Accessibility', () => {
     );
   });
 
-  it('should uses native disabled semantics for the default host', () => {
+  it('should use native disabled semantics for the default host', () => {
     const container = mount(<Button disabled>Save</Button>);
 
     try {
@@ -50,7 +50,7 @@ describe('Button - Accessibility', () => {
     }
   });
 
-  it('should uses aria-disabled and removes disabled asChild hosts from tab order', () => {
+  it('should use aria-disabled and remove disabled asChild hosts from tab order', () => {
     const container = mount(
       <Button asChild disabled>
         <a href="/docs">Docs</a>
@@ -67,7 +67,7 @@ describe('Button - Accessibility', () => {
     }
   });
 
-  it('should preserves accessible naming props from the host', () => {
+  it('should preserve accessible naming props from the host', () => {
     const container = mount(
       <div>
         <span key="button-label" id="button-label">
@@ -88,7 +88,7 @@ describe('Button - Accessibility', () => {
     }
   });
 
-  it('should matches the documented button accessibility contract', () => {
+  it('should match the documented button accessibility contract', () => {
     expect(BUTTON_A11Y_CONTRACT.ROLE).toBe('button');
     expect(BUTTON_A11Y_CONTRACT.KEYBOARD_ACTIVATION).toEqual([
       'Enter',

--- a/tests/browser/components/button/behavior.test.tsx
+++ b/tests/browser/components/button/behavior.test.tsx
@@ -13,7 +13,7 @@ describe('Button - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a native button with the default button type', () => {
+  it('should render a native button with the default button type', () => {
     container = mount(<Button>Save</Button>);
 
     const button = container.querySelector(
@@ -25,7 +25,7 @@ describe('Button - Behavior', () => {
     expect(button?.getAttribute('data-slot')).toBe('button');
   });
 
-  it('should invokes onPress and merges host props for native buttons', () => {
+  it('should invoke onPress and merge host props for native buttons', () => {
     const onPress = vi.fn();
 
     container = mount(
@@ -46,7 +46,7 @@ describe('Button - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should prevents native interaction when disabled', () => {
+  it('should prevent native interaction when disabled', () => {
     const onPress = vi.fn();
 
     container = mount(
@@ -67,7 +67,7 @@ describe('Button - Behavior', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
-  it('should supports asChild hosts with composed props and disabled semantics', () => {
+  it('should support asChild hosts with composed props and disabled semantics', () => {
     const onPress = vi.fn();
 
     container = mount(
@@ -174,7 +174,7 @@ describe('Button - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should activates a non-native asChild host with Enter and Space', async () => {
+  it('should activate a non-native asChild host with Enter and Space', async () => {
     const onPress = vi.fn();
     container = mount(
       <Button asChild onPress={onPress}>
@@ -191,7 +191,7 @@ describe('Button - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(2);
   });
 
-  it('should replaces stateful icon children instead of accumulating them', async () => {
+  it('should replace stateful icon children instead of accumulating them', async () => {
     const onPress = vi.fn();
 
     const ThemeLikeButton = () => {

--- a/tests/browser/components/button/determinism.test.tsx
+++ b/tests/browser/components/button/determinism.test.tsx
@@ -20,7 +20,7 @@ function unmount(container: HTMLElement) {
 }
 
 describe('Button - Determinism', () => {
-  it('should renders deterministic native button markup', () => {
+  it('should render deterministic native button markup', () => {
     expectDeterministicRender(() => <Button>Save</Button>);
     expectDeterministicRender(() => (
       <Button variant="ghost" size="lg">
@@ -34,7 +34,7 @@ describe('Button - Determinism', () => {
     ));
   });
 
-  it('should maps typed size and width affordances to stable data attributes', () => {
+  it('should map typed size and width affordances to stable data attributes', () => {
     const container = mount(
       <Button size="icon-xs" width="full">
         Open
@@ -53,7 +53,7 @@ describe('Button - Determinism', () => {
     }
   });
 
-  it('should renders deterministic asChild markup', () => {
+  it('should render deterministic asChild markup', () => {
     expectDeterministicRender(() => (
       <Button asChild data-testid="docs-link">
         <a href="/docs">Docs</a>
@@ -61,7 +61,7 @@ describe('Button - Determinism', () => {
     ));
   });
 
-  it('should keeps behavior props-driven across remounts', () => {
+  it('should keep behavior props-driven across remounts', () => {
     const firstPress = vi.fn();
     const secondPress = vi.fn();
 
@@ -90,7 +90,7 @@ describe('Button - Determinism', () => {
     }
   });
 
-  it('should does not schedule timers during render', () => {
+  it('should not schedule timers during render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(<Button>Save</Button>);

--- a/tests/browser/components/checkbox/a11y.test.tsx
+++ b/tests/browser/components/checkbox/a11y.test.tsx
@@ -5,7 +5,7 @@ import { mount, unmount } from '../../test-utils';
 import { CHECKBOX_A11Y_CONTRACT } from '../../../../src/components/checkbox/checkbox.a11y';
 
 describe('Checkbox - Accessibility', () => {
-  it('should has no automated axe violations for a labelled native checkbox', async () => {
+  it('should have no automated axe violations for a labelled native checkbox', async () => {
     await expectNoAxeViolations(
       <label>
         Accept terms
@@ -14,7 +14,7 @@ describe('Checkbox - Accessibility', () => {
     );
   });
 
-  it('should has no automated axe violations for a labelled asChild checkbox', async () => {
+  it('should have no automated axe violations for a labelled asChild checkbox', async () => {
     await expectNoAxeViolations(
       <Checkbox asChild>
         <div role="checkbox" aria-label="Accept terms">
@@ -24,7 +24,7 @@ describe('Checkbox - Accessibility', () => {
     );
   });
 
-  it('should uses implicit native checkbox semantics for the default host', () => {
+  it('should use implicit native checkbox semantics for the default host', () => {
     const container = mount(<Checkbox checked={false} />);
 
     try {
@@ -37,7 +37,7 @@ describe('Checkbox - Accessibility', () => {
     }
   });
 
-  it('should uses mixed aria state for indeterminate asChild hosts', () => {
+  it('should use mixed aria state for indeterminate asChild hosts', () => {
     const container = mount(
       <Checkbox asChild indeterminate>
         <div role="checkbox">Select all</div>
@@ -56,7 +56,7 @@ describe('Checkbox - Accessibility', () => {
     }
   });
 
-  it('should keeps native indeterminate checkboxes in the indeterminate state contract', () => {
+  it('should keep native indeterminate checkboxes in the indeterminate state contract', () => {
     const container = mount(<Checkbox indeterminate />);
 
     try {
@@ -69,7 +69,7 @@ describe('Checkbox - Accessibility', () => {
     }
   });
 
-  it('should uses aria-disabled and removes disabled asChild hosts from tab order', () => {
+  it('should use aria-disabled and remove disabled asChild hosts from tab order', () => {
     const container = mount(
       <Checkbox asChild disabled>
         <div role="checkbox">Disabled</div>
@@ -86,7 +86,7 @@ describe('Checkbox - Accessibility', () => {
     }
   });
 
-  it('should matches the documented checkbox accessibility contract', () => {
+  it('should match the documented checkbox accessibility contract', () => {
     expect(CHECKBOX_A11Y_CONTRACT.ROLE).toBe('checkbox');
     expect(CHECKBOX_A11Y_CONTRACT.KEYBOARD_ACTIVATION).toEqual([
       'Enter',

--- a/tests/browser/components/checkbox/behavior.test.tsx
+++ b/tests/browser/components/checkbox/behavior.test.tsx
@@ -12,7 +12,7 @@ describe('Checkbox - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a native checkbox input by default', () => {
+  it('should render a native checkbox input by default', () => {
     container = mount(<Checkbox />);
     const input = container.querySelector(
       'input[type="checkbox"]'
@@ -24,7 +24,7 @@ describe('Checkbox - Behavior', () => {
     expect(input?.getAttribute('aria-checked')).toBe('false');
   });
 
-  it('should invokes onPress exactly once per native click', () => {
+  it('should invoke onPress exactly once per native click', () => {
     const onPress = vi.fn();
 
     container = mount(<Checkbox onPress={onPress} />);
@@ -35,7 +35,7 @@ describe('Checkbox - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should emits uncontrolled state changes through onCheckedChange', async () => {
+  it('should emit uncontrolled state changes through onCheckedChange', async () => {
     const onCheckedChange = vi.fn();
 
     container = mount(
@@ -53,7 +53,7 @@ describe('Checkbox - Behavior', () => {
     expect(input?.getAttribute('data-state')).toBe('checked');
   });
 
-  it('should calls onCheckedChange in controlled mode', () => {
+  it('should call onCheckedChange in controlled mode', () => {
     const onCheckedChange = vi.fn();
 
     container = mount(
@@ -66,7 +66,7 @@ describe('Checkbox - Behavior', () => {
     expect(onCheckedChange).toHaveBeenCalledWith(true);
   });
 
-  it('should blocks native interaction when disabled', () => {
+  it('should block native interaction when disabled', () => {
     const onPress = vi.fn();
 
     container = mount(<Checkbox disabled onPress={onPress} />);
@@ -80,7 +80,7 @@ describe('Checkbox - Behavior', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
-  it('should applies checked and indeterminate state hooks to the native host', () => {
+  it('should apply checked and indeterminate state hooks to the native host', () => {
     container = mount(<Checkbox checked indeterminate />);
     const input = container.querySelector('input') as HTMLInputElement | null;
 
@@ -126,7 +126,7 @@ describe('Checkbox - Behavior', () => {
     expect(input.indeterminate).toBe(false);
   });
 
-  it('should forwards refs to the asChild host', () => {
+  it('should forward refs to the asChild host', () => {
     let refNode: HTMLElement | null = null;
 
     container = mount(
@@ -140,7 +140,7 @@ describe('Checkbox - Behavior', () => {
     expect(refNode).toBe(div);
   });
 
-  it('should toggles an asChild host with Enter and Space', async () => {
+  it('should toggle an asChild host with Enter and Space', async () => {
     const onCheckedChange = vi.fn();
     container = mount(
       <Checkbox asChild onCheckedChange={onCheckedChange}>
@@ -167,7 +167,7 @@ describe('Checkbox - Behavior', () => {
     expect(onCheckedChange.mock.calls).toEqual([[true], [false]]);
   });
 
-  it('should honors caller cancellation for asChild keyboard presses', async () => {
+  it('should honor caller cancellation for asChild keyboard presses', async () => {
     const onCheckedChange = vi.fn();
     container = mount(
       <Checkbox

--- a/tests/browser/components/checkbox/determinism.test.tsx
+++ b/tests/browser/components/checkbox/determinism.test.tsx
@@ -4,14 +4,14 @@ import { expectDeterministicRender } from '../../determinism';
 import { mount, unmount } from '../../test-utils';
 
 describe('Checkbox - Determinism', () => {
-  it('should renders deterministic native checkbox markup', () => {
+  it('should render deterministic native checkbox markup', () => {
     expectDeterministicRender(() => <Checkbox />);
     expectDeterministicRender(() => (
       <Checkbox checked disabled name="terms" value="accepted" />
     ));
   });
 
-  it('should renders deterministic indeterminate and asChild checkbox markup', () => {
+  it('should render deterministic indeterminate and asChild checkbox markup', () => {
     expectDeterministicRender(() => <Checkbox checked indeterminate />);
     expectDeterministicRender(() => (
       <Checkbox asChild checked>
@@ -20,7 +20,7 @@ describe('Checkbox - Determinism', () => {
     ));
   });
 
-  it('should preserves checkbox state signaling across remounts', () => {
+  it('should preserve checkbox state signaling across remounts', () => {
     let container = mount(<Checkbox checked={false} />);
 
     try {
@@ -44,7 +44,7 @@ describe('Checkbox - Determinism', () => {
     }
   });
 
-  it('should does not schedule timers during render', () => {
+  it('should not schedule timers during render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(<Checkbox checked />);

--- a/tests/browser/components/collapsible/behavior.test.tsx
+++ b/tests/browser/components/collapsible/behavior.test.tsx
@@ -148,7 +148,7 @@ describe('Collapsible — Behavior', () => {
       expect(span?.textContent).toBe('Custom Trigger');
     });
 
-    it('should toggles exactly once with Enter and Space on native and asChild triggers', async () => {
+    it('should toggle exactly once with Enter and Space on native and asChild triggers', async () => {
       const onNativeOpenChange = vi.fn();
       container = mount(
         <Collapsible onOpenChange={onNativeOpenChange}>
@@ -206,7 +206,7 @@ describe('Collapsible — Behavior', () => {
       expect(container.textContent).not.toContain('Child content');
     });
 
-    it('should preserves button styling props when trigger composes as child', () => {
+    it('should preserve button styling props when trigger composes as child', () => {
       container = mount(
         <Collapsible>
           <Button asChild variant="ghost" size="sm">

--- a/tests/browser/components/dialog/behavior.test.tsx
+++ b/tests/browser/components/dialog/behavior.test.tsx
@@ -115,7 +115,7 @@ describe('Dialog - Behavior', () => {
     expect(rerenderedDialogs[0]?.textContent).toBe('First dialog');
     expect(rerenderedDialogs[1]?.textContent).toBe('Second dialog');
   });
-  it('should toggles trigger expansion state when activated', async () => {
+  it('should toggle trigger expansion state when activated', async () => {
     container = mount(
       <Dialog>
         <DialogTrigger>Open dialog</DialogTrigger>
@@ -143,7 +143,7 @@ describe('Dialog - Behavior', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('should preserves button styling props when trigger and close compose as children', async () => {
+  it('should preserve button styling props when trigger and close compose as children', async () => {
     container = mount(
       <Dialog>
         <Button asChild variant="outline">
@@ -186,7 +186,7 @@ describe('Dialog - Behavior', () => {
     ).toBeNull();
   });
 
-  it('should opens and closes through asChild Enter and Space presses', async () => {
+  it('should open and close through asChild Enter and Space presses', async () => {
     container = mount(
       <Dialog>
         <DialogTrigger asChild>
@@ -229,7 +229,7 @@ describe('Dialog - Behavior', () => {
     ).toBeNull();
   });
 
-  it('should omits generated title and description references when those parts are absent', async () => {
+  it('should omit generated title and description references when those parts are absent', async () => {
     container = mount(
       <Dialog defaultOpen>
         <DialogTrigger>Open dialog</DialogTrigger>
@@ -250,7 +250,7 @@ describe('Dialog - Behavior', () => {
     expect(content.getAttribute('aria-describedby')).toBeNull();
   });
 
-  it('should keeps dialog open when DialogContent onDismiss is provided and handles Escape', async () => {
+  it('should keep dialog open when DialogContent onDismiss is provided and handle Escape', async () => {
     const onDismiss = vi.fn();
 
     container = mount(
@@ -283,7 +283,7 @@ describe('Dialog - Behavior', () => {
     ).not.toBeNull();
   });
 
-  it('should keeps centered dialog content within viewport padding on narrow viewports', async () => {
+  it('should keep centered dialog content within viewport padding on narrow viewports', async () => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
       (callback: FrameRequestCallback) => {
         callback(0);

--- a/tests/browser/components/dismissable-layer/behavior.test.tsx
+++ b/tests/browser/components/dismissable-layer/behavior.test.tsx
@@ -10,7 +10,7 @@ describe('DismissableLayer - Behavior', () => {
     unmount(container);
   });
 
-  it('should dismisses on Escape for the mounted layer', () => {
+  it('should dismiss on Escape for the mounted layer', () => {
     const onDismiss = vi.fn();
 
     container = mount(
@@ -27,7 +27,7 @@ describe('DismissableLayer - Behavior', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('should dismisses on document Escape for the top layer', () => {
+  it('should dismiss on document Escape for the top layer', () => {
     const onDismiss = vi.fn();
 
     container = mount(
@@ -43,7 +43,7 @@ describe('DismissableLayer - Behavior', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('should dismisses on outside pointer down', () => {
+  it('should dismiss on outside pointer down', () => {
     const onDismiss = vi.fn();
 
     container = mount(
@@ -59,7 +59,7 @@ describe('DismissableLayer - Behavior', () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
-  it('should honors prevented outside pointer dismissals', () => {
+  it('should honor prevented outside pointer dismissals', () => {
     const onDismiss = vi.fn();
 
     container = mount(
@@ -78,7 +78,7 @@ describe('DismissableLayer - Behavior', () => {
     expect(onDismiss).toHaveBeenCalledTimes(0);
   });
 
-  it('should dismisses only the top layer when layers are stacked', () => {
+  it('should dismiss only the top layer when layers are stacked', () => {
     const outerDismiss = vi.fn();
     const innerDismiss = vi.fn();
 
@@ -105,7 +105,7 @@ describe('DismissableLayer - Behavior', () => {
     expect(outerDismiss).toHaveBeenCalledTimes(0);
   });
 
-  it('should does not dismiss when layer is disabled', () => {
+  it('should not dismiss when layer is disabled', () => {
     const onDismiss = vi.fn();
 
     container = mount(

--- a/tests/browser/components/dropdown/behavior.test.tsx
+++ b/tests/browser/components/dropdown/behavior.test.tsx
@@ -16,7 +16,7 @@ describe('Dropdown - Behavior', () => {
     unmount(container);
   });
 
-  it('should toggles trigger expansion state when activated', async () => {
+  it('should toggle trigger expansion state when activated', async () => {
     container = mount(
       <Dropdown>
         <DropdownTrigger>Open dropdown</DropdownTrigger>
@@ -66,7 +66,7 @@ describe('Dropdown - Behavior', () => {
     expect(document.activeElement?.textContent).toBe('Archive');
   });
 
-  it('should renders typed trigger and item variants for themed menus', async () => {
+  it('should render typed trigger and item variants for themed menus', async () => {
     container = mount(
       <Dropdown defaultOpen>
         <DropdownTrigger variant="ghost" size="icon" aria-label="Open menu">
@@ -98,7 +98,7 @@ describe('Dropdown - Behavior', () => {
     expect(item.getAttribute('data-variant')).toBe('destructive');
   });
 
-  it('should supports nested dropdown item composition without direct child injection', async () => {
+  it('should support nested dropdown item composition without direct child injection', async () => {
     container = mount(
       <Dropdown defaultOpen>
         <DropdownTrigger>Open dropdown</DropdownTrigger>
@@ -127,7 +127,7 @@ describe('Dropdown - Behavior', () => {
     expect(items[1]?.getAttribute('tabindex')).toBe('-1');
   });
 
-  it('should keeps dropdown open when all items are disabled and arrow navigation is attempted', async () => {
+  it('should keep dropdown open when all items are disabled and arrow navigation is attempted', async () => {
     container = mount(
       <Dropdown defaultOpen>
         <DropdownTrigger>Open dropdown</DropdownTrigger>
@@ -166,7 +166,7 @@ describe('Dropdown - Behavior', () => {
     ).toBe(true);
   });
 
-  it('should supports menu-button opening, typeahead, activation, and Tab dismissal', async () => {
+  it('should support menu-button opening, typeahead, activation, and Tab dismissal', async () => {
     const onArchiveSelect = vi.fn();
     container = mount(
       <div>
@@ -249,7 +249,7 @@ describe('Dropdown - Behavior', () => {
     );
   });
 
-  it('should activates an asChild item with Space', async () => {
+  it('should activate an asChild item with Space', async () => {
     const onSelect = vi.fn();
     container = mount(
       <Dropdown defaultOpen>

--- a/tests/browser/components/focus-scope/behavior.test.tsx
+++ b/tests/browser/components/focus-scope/behavior.test.tsx
@@ -10,7 +10,7 @@ describe('FocusScope - Behavior', () => {
     document.body.innerHTML = '';
   });
 
-  it('should supports manual focus inside the scope without breaking the focus target', () => {
+  it('should support manual focus inside the scope without breaking the focus target', () => {
     const trigger = document.createElement('button');
     trigger.textContent = 'Before';
     document.body.appendChild(trigger);
@@ -30,7 +30,7 @@ describe('FocusScope - Behavior', () => {
     expect(document.activeElement).not.toBe(trigger);
   });
 
-  it('should wraps keyboard focus when loop is enabled', () => {
+  it('should wrap keyboard focus when loop is enabled', () => {
     container = mount(
       <FocusScope loop>
         <button type="button">First</button>
@@ -52,7 +52,7 @@ describe('FocusScope - Behavior', () => {
     expect(document.activeElement).toBe(first);
   });
 
-  it('should keeps focus trapped within scope on focus-out when trapped is enabled', () => {
+  it('should keep focus trapped within scope on focus-out when trapped is enabled', () => {
     const outside = document.createElement('button');
     outside.textContent = 'Outside';
     document.body.appendChild(outside);

--- a/tests/browser/components/form/behavior.test.tsx
+++ b/tests/browser/components/form/behavior.test.tsx
@@ -10,7 +10,7 @@ describe('Form - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a canonical form surface by default', async () => {
+  it('should render a canonical form surface by default', async () => {
     container = mount(
       <Form method="post">
         <button type="submit">Save</button>
@@ -25,7 +25,7 @@ describe('Form - Behavior', () => {
     expect(form?.getAttribute('method')).toBe('post');
   });
 
-  it('should supports asChild composition for non-form hosts', async () => {
+  it('should support asChild composition for non-form hosts', async () => {
     container = mount(
       <Form asChild>
         <section>Fields</section>

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -16,7 +16,7 @@ describe('HoverCard - Behavior', () => {
     container = undefined;
   });
 
-  it('should opens and closes from hover and focus state changes', async () => {
+  it('should open and close from hover and focus state changes', async () => {
     vi.useFakeTimers();
 
     container = mount(
@@ -59,7 +59,7 @@ describe('HoverCard - Behavior', () => {
     ).toBeNull();
   });
 
-  it('should supports asChild composition and ref forwarding', async () => {
+  it('should support asChild composition and ref forwarding', async () => {
     const triggerRef = { current: null as HTMLAnchorElement | null };
     const contentRef = { current: null as HTMLElement | null };
 

--- a/tests/browser/components/input/a11y.test.tsx
+++ b/tests/browser/components/input/a11y.test.tsx
@@ -5,11 +5,11 @@ import { expectNoAxeViolations } from '../../accessibility';
 import { mount, unmount } from '../../test-utils';
 
 describe('Input - Accessibility', () => {
-  it('should has no automated axe violations for a labelled native input', async () => {
+  it('should have no automated axe violations for a labelled native input', async () => {
     await expectNoAxeViolations(<Input aria-label="Email" type="email" />);
   });
 
-  it('should has no automated axe violations for a labelled asChild input', async () => {
+  it('should have no automated axe violations for a labelled asChild input', async () => {
     await expectNoAxeViolations(
       <Input asChild>
         <input aria-label="Email" type="email" />
@@ -17,7 +17,7 @@ describe('Input - Accessibility', () => {
     );
   });
 
-  it('should uses native disabled semantics for the default host', () => {
+  it('should use native disabled semantics for the default host', () => {
     const container = mount(<Input aria-label="Email" disabled />);
 
     try {
@@ -32,7 +32,7 @@ describe('Input - Accessibility', () => {
     }
   });
 
-  it('should uses native disabled semantics for disabled asChild input hosts', () => {
+  it('should use native disabled semantics for disabled asChild input hosts', () => {
     const container = mount(
       <Input asChild disabled>
         <input aria-label="Email" />
@@ -51,7 +51,7 @@ describe('Input - Accessibility', () => {
     }
   });
 
-  it('should matches the documented input accessibility contract', () => {
+  it('should match the documented input accessibility contract', () => {
     expect(INPUT_A11Y_CONTRACT.HOST_ELEMENT).toBe('input');
     expect(INPUT_A11Y_CONTRACT.DISABLED_ATTRIBUTES).toEqual({
       native: 'disabled',

--- a/tests/browser/components/input/behavior.test.tsx
+++ b/tests/browser/components/input/behavior.test.tsx
@@ -13,7 +13,7 @@ describe('Input - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a native input by default', () => {
+  it('should render a native input by default', () => {
     container = mount(<Input type="email" placeholder="Email" />);
 
     const input = container.querySelector('input') as HTMLInputElement | null;
@@ -24,7 +24,7 @@ describe('Input - Behavior', () => {
     expect(input?.getAttribute('data-slot')).toBe('input');
   });
 
-  it('should applies disabled and readonly semantics to native inputs', () => {
+  it('should apply disabled and readonly semantics to native inputs', () => {
     container = mount(<Input disabled readOnly aria-label="locked-input" />);
 
     const input = container.querySelector('input') as HTMLInputElement | null;
@@ -36,7 +36,7 @@ describe('Input - Behavior', () => {
     expect(input?.hasAttribute('readonly')).toBe(true);
   });
 
-  it('should supports asChild composition and merges host props', () => {
+  it('should support asChild composition and merge host props', () => {
     container = mount(
       <Input asChild data-testid="custom-input" data-from-input="yes">
         <input aria-label="Email" data-from-child="yes" />
@@ -51,7 +51,7 @@ describe('Input - Behavior', () => {
     expect(input?.getAttribute('data-slot')).toBe('input');
   });
 
-  it('should applies disabled semantics to asChild input hosts', () => {
+  it('should apply disabled semantics to asChild input hosts', () => {
     container = mount(
       <Input asChild disabled>
         <input aria-label="Email" />
@@ -65,7 +65,7 @@ describe('Input - Behavior', () => {
     expect(host?.getAttribute('tabindex')).toBe('-1');
   });
 
-  it('should uses search as the default debounced input type', () => {
+  it('should use search as the default debounced input type', () => {
     container = mount(<DebouncedInput aria-label="Search" />);
 
     const input = container.querySelector('input') as HTMLInputElement | null;
@@ -73,7 +73,7 @@ describe('Input - Behavior', () => {
     expect(input?.type).toBe('search');
   });
 
-  it('should preserves input identity and value through sibling rerenders', async () => {
+  it('should preserve input identity and value through sibling rerenders', async () => {
     const InputFixture = () => {
       const value = state('');
       const version = state(0);
@@ -124,7 +124,7 @@ describe('Input - Behavior', () => {
     );
   });
 
-  it('should forwards onInput and debounces committed value', async () => {
+  it('should forward onInput and debounce committed value', async () => {
     vi.useFakeTimers();
 
     const typedValues: string[] = [];
@@ -160,7 +160,7 @@ describe('Input - Behavior', () => {
     expect(committedValues).toEqual(['nor']);
   });
 
-  it('should emits immediate committed input when debounceMs is zero', () => {
+  it('should emit immediate committed input when debounceMs is zero', () => {
     const committedValues: string[] = [];
 
     container = mount(
@@ -177,7 +177,7 @@ describe('Input - Behavior', () => {
     expect(committedValues).toEqual(['northwind']);
   });
 
-  it('should cancels pending debounced input on unmount', () => {
+  it('should cancel pending debounced input on unmount', () => {
     vi.useFakeTimers();
 
     const committedValues: string[] = [];

--- a/tests/browser/components/input/determinism.test.tsx
+++ b/tests/browser/components/input/determinism.test.tsx
@@ -4,13 +4,13 @@ import { expectDeterministicRender } from '../../determinism';
 import { mount, unmount } from '../../test-utils';
 
 describe('Input - Determinism', () => {
-  it('should renders deterministic native input markup', () => {
+  it('should render deterministic native input markup', () => {
     expectDeterministicRender(() => (
       <Input type="email" placeholder="Email" disabled />
     ));
   });
 
-  it('should renders deterministic asChild and debounced input markup', () => {
+  it('should render deterministic asChild and debounced input markup', () => {
     expectDeterministicRender(() => (
       <Input asChild>
         <input aria-label="Email" />
@@ -21,7 +21,7 @@ describe('Input - Determinism', () => {
     ));
   });
 
-  it('should does not schedule timers during debounced input render', () => {
+  it('should not schedule timers during debounced input render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(

--- a/tests/browser/components/label/a11y.test.tsx
+++ b/tests/browser/components/label/a11y.test.tsx
@@ -5,7 +5,7 @@ import { expectNoAxeViolations } from '../../accessibility';
 import { mount, unmount } from '../../test-utils';
 
 describe('Label - Accessibility', () => {
-  it('should has no automated axe violations given labelled form control', async () => {
+  it('should have no automated axe violations given labelled form control', async () => {
     await expectNoAxeViolations(
       <div>
         <Label key="label" htmlFor="email">
@@ -29,7 +29,7 @@ describe('Label - Accessibility', () => {
     }
   });
 
-  it('should matches the documented label accessibility contract', () => {
+  it('should match the documented label accessibility contract', () => {
     expect(LABEL_A11Y_CONTRACT.ELEMENT).toBe('label');
     expect(LABEL_A11Y_CONTRACT.ASSOCIATION_ATTRIBUTE).toBe('for');
     expect(LABEL_A11Y_CONTRACT.DATA_ATTRIBUTES).toEqual({

--- a/tests/browser/components/label/behavior.test.tsx
+++ b/tests/browser/components/label/behavior.test.tsx
@@ -10,7 +10,7 @@ describe('Label - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a native label by default', () => {
+  it('should render a native label by default', () => {
     container = mount(<Label htmlFor="email">Email</Label>);
     const label = container.querySelector('label') as HTMLLabelElement | null;
 
@@ -20,7 +20,7 @@ describe('Label - Behavior', () => {
     expect(label?.getAttribute('data-slot')).toBe('label');
   });
 
-  it('should supports asChild composition and merges host props', () => {
+  it('should support asChild composition and merge host props', () => {
     container = mount(
       <Label asChild data-testid="email-label" data-from-label="yes">
         <span data-from-child="yes">Email</span>

--- a/tests/browser/components/label/determinism.test.tsx
+++ b/tests/browser/components/label/determinism.test.tsx
@@ -3,11 +3,11 @@ import { Label } from '../../../../src/components/label/label';
 import { expectDeterministicRender } from '../../determinism';
 
 describe('Label - Determinism', () => {
-  it('should renders deterministic native label markup', () => {
+  it('should render deterministic native label markup', () => {
     expectDeterministicRender(() => <Label htmlFor="email">Email</Label>);
   });
 
-  it('should renders deterministic asChild label markup', () => {
+  it('should render deterministic asChild label markup', () => {
     expectDeterministicRender(() => (
       <Label asChild data-testid="email-label">
         <span>Email</span>

--- a/tests/browser/components/menu/behavior.test.tsx
+++ b/tests/browser/components/menu/behavior.test.tsx
@@ -16,7 +16,7 @@ describe('Menu - Behavior', () => {
     unmount(container);
   });
 
-  it('should renders menu semantics with a single tab stop', () => {
+  it('should render menu semantics with a single tab stop', () => {
     container = mount(
       <Menu>
         <MenuContent>
@@ -34,7 +34,7 @@ describe('Menu - Behavior', () => {
     expect(items[1].getAttribute('tabindex')).toBe('-1');
   });
 
-  it('should supports nested menu item composition without direct child injection', () => {
+  it('should support nested menu item composition without direct child injection', () => {
     container = mount(
       <Menu>
         <MenuContent>
@@ -54,7 +54,7 @@ describe('Menu - Behavior', () => {
     expect(items[1].getAttribute('tabindex')).toBe('-1');
   });
 
-  it('should supports typeahead, activation keys, and a single Tab stop', async () => {
+  it('should support typeahead, activation keys, and a single Tab stop', async () => {
     const onArchiveSelect = vi.fn();
     container = mount(
       <div>

--- a/tests/browser/components/menubar/behavior.test.tsx
+++ b/tests/browser/components/menubar/behavior.test.tsx
@@ -49,7 +49,7 @@ describe('Menubar - Behavior', () => {
     unmount(container);
   });
 
-  it('should opens top-level triggers and nested submenus', async () => {
+  it('should open top-level triggers and nested submenus', async () => {
     container = mount(
       <Menubar>
         <MenubarMenu value="file">
@@ -89,7 +89,7 @@ describe('Menubar - Behavior', () => {
     expect(document.body.textContent).toContain('Email');
   });
 
-  it('should supports keyboard opening and escape dismissal', async () => {
+  it('should support keyboard opening and escape dismissal', async () => {
     container = mount(
       <Menubar>
         <MenubarMenu value="file">
@@ -121,7 +121,7 @@ describe('Menubar - Behavior', () => {
     expect(document.body.textContent).not.toContain('New');
   });
 
-  it('should supports typeahead, activation keys, submenus, and Tab dismissal', async () => {
+  it('should support typeahead, activation keys, submenus, and Tab dismissal', async () => {
     const onArchiveAction = vi.fn();
     container = mount(
       <div>
@@ -273,7 +273,7 @@ describe('Menubar - Behavior', () => {
     );
   });
 
-  it('should preserves Enter activation for asChild menu and submenu triggers', async () => {
+  it('should preserve Enter activation for asChild menu and submenu triggers', async () => {
     const onFilePress = vi.fn();
     container = mount(
       <Menubar>

--- a/tests/browser/components/popover/behavior.test.tsx
+++ b/tests/browser/components/popover/behavior.test.tsx
@@ -23,7 +23,7 @@ describe('Popover - Behavior', () => {
     unmount(container);
   });
 
-  it('should toggles trigger expansion state through the trigger', async () => {
+  it('should toggle trigger expansion state through the trigger', async () => {
     container = mount(
       <Popover>
         <PopoverTrigger>Open popover</PopoverTrigger>
@@ -49,7 +49,7 @@ describe('Popover - Behavior', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('should applies trigger-based dialog labeling by default', async () => {
+  it('should apply trigger-based dialog labeling by default', async () => {
     container = mount(
       <Popover defaultOpen>
         <PopoverTrigger>Open popover</PopoverTrigger>
@@ -70,7 +70,7 @@ describe('Popover - Behavior', () => {
     expect(content?.getAttribute('aria-labelledby')).toBe(trigger?.id);
   });
 
-  it('should opens and closes through asChild Enter and Space presses', async () => {
+  it('should open and close through asChild Enter and Space presses', async () => {
     container = mount(
       <Popover>
         <PopoverTrigger asChild>
@@ -113,7 +113,7 @@ describe('Popover - Behavior', () => {
     ).toBeNull();
   });
 
-  it('should maps typed width affordance to a stable data attribute', async () => {
+  it('should map typed width affordance to a stable data attribute', async () => {
     container = mount(
       <Popover defaultOpen>
         <PopoverTrigger>Open popover</PopoverTrigger>
@@ -130,7 +130,7 @@ describe('Popover - Behavior', () => {
     expect(content?.getAttribute('data-width')).toBe('md');
   });
 
-  it('should preserves explicit aria-label over automatic trigger labeling', async () => {
+  it('should preserve explicit aria-label over automatic trigger labeling', async () => {
     container = mount(
       <Popover defaultOpen>
         <PopoverTrigger>Open popover</PopoverTrigger>
@@ -149,7 +149,7 @@ describe('Popover - Behavior', () => {
     expect(content?.hasAttribute('aria-labelledby')).toBe(false);
   });
 
-  it('should keeps custom content positioning through the post-open portal sync', async () => {
+  it('should keep custom content positioning through the post-open portal sync', async () => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
       (callback: FrameRequestCallback) => {
         callback(0);
@@ -231,7 +231,7 @@ describe('Popover - Behavior', () => {
     expect(getComputedStyle(content as Element).top).toBe('90px');
   });
 
-  it('should closes nested popover without closing parent dialog on Escape', async () => {
+  it('should close nested popover without closing parent dialog on Escape', async () => {
     container = mount(
       <Dialog defaultOpen>
         <DialogTrigger>Open dialog</DialogTrigger>

--- a/tests/browser/components/radio-group/a11y.test.tsx
+++ b/tests/browser/components/radio-group/a11y.test.tsx
@@ -8,7 +8,7 @@ import { expectNoAxeViolations } from '../../accessibility';
 import { mount, unmount } from '../../test-utils';
 
 describe('RadioGroup - Accessibility', () => {
-  it('should has no automated axe violations for labelled native radio items', async () => {
+  it('should have no automated axe violations for labelled native radio items', async () => {
     await expectNoAxeViolations(
       <RadioGroup aria-label="Size" defaultValue="m">
         <RadioGroupItem value="s">Small</RadioGroupItem>
@@ -17,7 +17,7 @@ describe('RadioGroup - Accessibility', () => {
     );
   });
 
-  it('should has no automated axe violations for labelled asChild radio items', async () => {
+  it('should have no automated axe violations for labelled asChild radio items', async () => {
     await expectNoAxeViolations(
       <RadioGroup aria-label="Alignment" defaultValue="center">
         <RadioGroupItem asChild value="left">
@@ -30,7 +30,7 @@ describe('RadioGroup - Accessibility', () => {
     );
   });
 
-  it('should exposes radiogroup, orientation, and checked semantics', () => {
+  it('should expose radiogroup, orientation, and checked semantics', () => {
     const container = mount(
       <RadioGroup aria-label="Size" defaultValue="m" orientation="horizontal">
         <RadioGroupItem value="s">Small</RadioGroupItem>
@@ -66,7 +66,7 @@ describe('RadioGroup - Accessibility', () => {
     }
   });
 
-  it('should omits aria-orientation when orientation is both', () => {
+  it('should omit aria-orientation when orientation is both', () => {
     const container = mount(
       <RadioGroup
         aria-label="Two dimensional"
@@ -88,7 +88,7 @@ describe('RadioGroup - Accessibility', () => {
     }
   });
 
-  it('should uses disabled semantics for asChild radio items without native button support', () => {
+  it('should use disabled semantics for asChild radio items without native button support', () => {
     const container = mount(
       <RadioGroup aria-label="Alignment" defaultValue="left">
         <RadioGroupItem asChild value="left" disabled>
@@ -107,7 +107,7 @@ describe('RadioGroup - Accessibility', () => {
     }
   });
 
-  it('should matches the documented radio group accessibility contract', () => {
+  it('should match the documented radio group accessibility contract', () => {
     expect(RADIO_GROUP_A11Y_CONTRACT).toEqual({
       GROUP_ROLE: 'radiogroup',
       ITEM_ROLE: 'radio',

--- a/tests/browser/components/radio-group/behavior.test.tsx
+++ b/tests/browser/components/radio-group/behavior.test.tsx
@@ -28,7 +28,7 @@ describe('RadioGroup - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders the radiogroup container and checked hooks in uncontrolled mode', () => {
+  it('should render the radiogroup container and checked hooks in uncontrolled mode', () => {
     container = mount(
       <RadioGroup defaultValue="medium" orientation="horizontal">
         <RadioGroupItem value="small">Small</RadioGroupItem>
@@ -53,7 +53,7 @@ describe('RadioGroup - Behavior', () => {
     expect(medium.getAttribute('data-state')).toBe('checked');
   });
 
-  it('should updates uncontrolled selection and hidden input value', async () => {
+  it('should update uncontrolled selection and hidden input value', async () => {
     container = mount(
       <RadioGroup name="size" defaultValue="small">
         <RadioGroupItem value="small">Small</RadioGroupItem>
@@ -75,7 +75,7 @@ describe('RadioGroup - Behavior', () => {
     ).toBe('medium');
   });
 
-  it('should supports nested radio items without relying on direct child cloning', async () => {
+  it('should support nested radio items without relying on direct child cloning', async () => {
     container = mount(
       <RadioGroup name="size" defaultValue="small">
         <div>
@@ -101,7 +101,7 @@ describe('RadioGroup - Behavior', () => {
     ).toBe('medium');
   });
 
-  it('should treats value as controlled state when provided', async () => {
+  it('should treat value as controlled state when provided', async () => {
     const onValueChange = vi.fn();
 
     container = mount(
@@ -123,7 +123,7 @@ describe('RadioGroup - Behavior', () => {
     ).toBe('false');
   });
 
-  it('should blocks interaction when the group or item is disabled', async () => {
+  it('should block interaction when the group or item is disabled', async () => {
     const onGroupValueChange = vi.fn();
     const onItemValueChange = vi.fn();
 
@@ -168,7 +168,7 @@ describe('RadioGroup - Behavior', () => {
     ).toBe('true');
   });
 
-  it('should supports asChild item composition and merges host props', () => {
+  it('should support asChild item composition and merge host props', () => {
     container = mount(
       <RadioGroup defaultValue="left">
         <RadioGroupItem
@@ -191,7 +191,7 @@ describe('RadioGroup - Behavior', () => {
     expect(host.getAttribute('data-state')).toBe('checked');
   });
 
-  it('should activates asChild items with Enter and Space', async () => {
+  it('should activate asChild items with Enter and Space', async () => {
     container = mount(
       <RadioGroup defaultValue="small">
         <RadioGroupItem value="small">Small</RadioGroupItem>
@@ -225,7 +225,7 @@ describe('RadioGroup - Behavior', () => {
     ).toBe('true');
   });
 
-  it('should forwards refs to the group container and item hosts', () => {
+  it('should forward refs to the group container and item hosts', () => {
     let groupRef: HTMLDivElement | null = null;
     let nativeItemRef: HTMLButtonElement | null = null;
     let childItemRef: HTMLElement | null = null;
@@ -262,7 +262,7 @@ describe('RadioGroup - Behavior', () => {
     expect(childItemRef).toBe(childHost);
   });
 
-  it('should renders a hidden input only when name is provided', () => {
+  it('should render a hidden input only when name is provided', () => {
     container = mount(
       <div>
         <RadioGroup defaultValue="small">
@@ -282,7 +282,7 @@ describe('RadioGroup - Behavior', () => {
     expect(inputs[0]?.getAttribute('value')).toBe('medium');
   });
 
-  it('should does not wrap selection at boundaries when loop is false', async () => {
+  it('should not wrap selection at boundaries when loop is false', async () => {
     container = mount(
       <RadioGroup defaultValue="small" orientation="horizontal" loop={false}>
         <RadioGroupItem value="small">Small</RadioGroupItem>
@@ -305,7 +305,7 @@ describe('RadioGroup - Behavior', () => {
     ).toBe('false');
   });
 
-  it('should does not activate disabled items during keyboard navigation attempts', async () => {
+  it('should not activate disabled items during keyboard navigation attempts', async () => {
     container = mount(
       <RadioGroup defaultValue="small" orientation="vertical">
         <RadioGroupItem value="small">Small</RadioGroupItem>

--- a/tests/browser/components/radio-group/determinism.test.tsx
+++ b/tests/browser/components/radio-group/determinism.test.tsx
@@ -7,7 +7,7 @@ import { expectDeterministicRender } from '../../determinism';
 import { mount, unmount } from '../../test-utils';
 
 describe('RadioGroup - Determinism', () => {
-  it('should renders deterministic radio group markup for named and unnamed groups', () => {
+  it('should render deterministic radio group markup for named and unnamed groups', () => {
     expectDeterministicRender(() => (
       <RadioGroup defaultValue="m" name="size">
         <RadioGroupItem value="s">Small</RadioGroupItem>
@@ -22,7 +22,7 @@ describe('RadioGroup - Determinism', () => {
     ));
   });
 
-  it('should renders deterministic asChild radio item markup', () => {
+  it('should render deterministic asChild radio item markup', () => {
     expectDeterministicRender(() => (
       <RadioGroup defaultValue="left">
         <RadioGroupItem asChild value="left">
@@ -32,7 +32,7 @@ describe('RadioGroup - Determinism', () => {
     ));
   });
 
-  it('should keeps checked state props-driven across remounts', () => {
+  it('should keep checked state props-driven across remounts', () => {
     let container = mount(
       <RadioGroup defaultValue="small" name="size">
         <RadioGroupItem value="small">Small</RadioGroupItem>
@@ -80,7 +80,7 @@ describe('RadioGroup - Determinism', () => {
     }
   });
 
-  it('should does not schedule timers during render', () => {
+  it('should not schedule timers during render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(

--- a/tests/browser/components/scroll-area/behavior.test.tsx
+++ b/tests/browser/components/scroll-area/behavior.test.tsx
@@ -16,7 +16,7 @@ describe('ScrollArea - Behavior', () => {
     container = undefined;
   });
 
-  it('should exposes canonical viewport and scrollbar hooks', async () => {
+  it('should expose canonical viewport and scrollbar hooks', async () => {
     container = mount(
       <ScrollArea>
         <ScrollAreaViewport>
@@ -45,7 +45,7 @@ describe('ScrollArea - Behavior', () => {
     ).toBeTruthy();
   });
 
-  it('should does not emit inline viewport styles and rejects orphan parts', async () => {
+  it('should not emit inline viewport styles and should reject orphan parts', async () => {
     container = mount(
       <ScrollArea>
         <ScrollAreaViewport

--- a/tests/browser/components/select/behavior.test.tsx
+++ b/tests/browser/components/select/behavior.test.tsx
@@ -21,7 +21,7 @@ describe('Select - Behavior', () => {
     unmount(container);
   });
 
-  it('should wires the hidden input and trigger expansion state', async () => {
+  it('should wire the hidden input and trigger expansion state', async () => {
     container = mount(
       <Select name="framework" defaultValue="askr">
         <SelectTrigger>
@@ -54,7 +54,7 @@ describe('Select - Behavior', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('true');
   });
 
-  it('should renders typed trigger size for themed select controls', () => {
+  it('should render typed trigger size for themed select controls', () => {
     container = mount(
       <Select defaultValue="askr">
         <SelectTrigger size="sm">
@@ -75,7 +75,7 @@ describe('Select - Behavior', () => {
     expect(trigger.getAttribute('data-size')).toBe('sm');
   });
 
-  it('should applies root disabled semantics to the trigger and hidden input', async () => {
+  it('should apply root disabled semantics to the trigger and hidden input', async () => {
     container = mount(
       <Select disabled name="framework" defaultValue="askr">
         <SelectTrigger>
@@ -107,7 +107,7 @@ describe('Select - Behavior', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('should uses explicit item text values for trigger rendering', () => {
+  it('should use explicit item text values for trigger rendering', () => {
     container = mount(
       <Select defaultValue="askr">
         <SelectTrigger>
@@ -134,7 +134,7 @@ describe('Select - Behavior', () => {
     expect(trigger.textContent).toBe('Askr');
   });
 
-  it('should labels select groups through nested SelectLabel parts', async () => {
+  it('should label select groups through nested SelectLabel parts', async () => {
     container = mount(
       <Select defaultOpen defaultValue="askr">
         <SelectTrigger aria-label="Framework">
@@ -166,7 +166,7 @@ describe('Select - Behavior', () => {
     expect(group.getAttribute('aria-labelledby')).toBe(label.id);
   });
 
-  it('should updates hidden input and closes content when an enabled item is selected', async () => {
+  it('should update hidden input and close content when an enabled item is selected', async () => {
     container = mount(
       <Select name="framework" defaultValue="askr">
         <SelectTrigger>
@@ -206,7 +206,7 @@ describe('Select - Behavior', () => {
     expect(nextTrigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('should does not change value when clicking a disabled item', async () => {
+  it('should not change value when clicking a disabled item', async () => {
     container = mount(
       <Select name="framework" defaultValue="askr">
         <SelectTrigger>
@@ -248,7 +248,7 @@ describe('Select - Behavior', () => {
     expect(nextTrigger.textContent).toContain('Askr');
   });
 
-  it('should keeps all disabled select items unfocusable when navigation is attempted', async () => {
+  it('should keep all disabled select items unfocusable when navigation is attempted', async () => {
     container = mount(
       <Select defaultOpen defaultValue="askr">
         <SelectTrigger>
@@ -280,7 +280,7 @@ describe('Select - Behavior', () => {
     );
   });
 
-  it('should supports buffered typeahead from the trigger and listbox focus', async () => {
+  it('should support buffered typeahead from the trigger and listbox focus', async () => {
     vi.useFakeTimers();
     container = mount(
       <Select name="database" defaultValue="alpha">
@@ -413,7 +413,7 @@ describe('Select - Behavior', () => {
     );
   });
 
-  it('should keeps arrow, Space, Enter, and Tab interactions intuitive', async () => {
+  it('should keep arrow, Space, Enter, and Tab interactions intuitive', async () => {
     container = mount(
       <div>
         <Select name="framework" defaultValue="alpha">
@@ -484,7 +484,7 @@ describe('Select - Behavior', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('should opens with Space and moves past the popup with Tab', async () => {
+  it('should open with Space and move past the popup with Tab', async () => {
     container = mount(
       <div>
         <Select defaultValue="alpha">
@@ -529,7 +529,7 @@ describe('Select - Behavior', () => {
     );
   });
 
-  it('should opens an asChild trigger with Enter', async () => {
+  it('should open an asChild trigger with Enter', async () => {
     container = mount(
       <Select defaultValue="alpha">
         <SelectTrigger asChild>

--- a/tests/browser/components/switch/a11y.test.tsx
+++ b/tests/browser/components/switch/a11y.test.tsx
@@ -5,11 +5,11 @@ import { expectNoAxeViolations } from '../../accessibility';
 import { mount, unmount } from '../../test-utils';
 
 describe('Switch - Accessibility', () => {
-  it('should has no automated axe violations for the native switch path', async () => {
+  it('should have no automated axe violations for the native switch path', async () => {
     await expectNoAxeViolations(<Switch>Airplane mode</Switch>);
   });
 
-  it('should has no automated axe violations for labelled asChild composition', async () => {
+  it('should have no automated axe violations for labelled asChild composition', async () => {
     await expectNoAxeViolations(
       <Switch asChild>
         <div aria-label="Power">Power</div>
@@ -17,7 +17,7 @@ describe('Switch - Accessibility', () => {
     );
   });
 
-  it('should exposes switch semantics when composed with asChild', () => {
+  it('should expose switch semantics when composed with asChild', () => {
     const container = mount(
       <Switch asChild defaultChecked>
         <div>Power</div>
@@ -37,7 +37,7 @@ describe('Switch - Accessibility', () => {
     }
   });
 
-  it('should uses native disabled semantics and hidden form integration when named', () => {
+  it('should use native disabled semantics and hidden form integration when named', () => {
     const container = mount(
       <Switch disabled name="power" value="enabled">
         Power
@@ -60,7 +60,7 @@ describe('Switch - Accessibility', () => {
     }
   });
 
-  it('should matches the documented switch accessibility contract', () => {
+  it('should match the documented switch accessibility contract', () => {
     expect(SWITCH_A11Y_CONTRACT.ROLE).toBe('switch');
     expect(SWITCH_A11Y_CONTRACT.CHECKED_ATTRIBUTE).toBe('aria-checked');
     expect(SWITCH_A11Y_CONTRACT.KEYBOARD_ACTIVATION).toEqual([

--- a/tests/browser/components/switch/behavior.test.tsx
+++ b/tests/browser/components/switch/behavior.test.tsx
@@ -12,7 +12,7 @@ describe('Switch - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders native switch semantics by default', () => {
+  it('should render native switch semantics by default', () => {
     container = mount(<Switch>Airplane mode</Switch>);
     const button = container.querySelector(
       'button'
@@ -27,7 +27,7 @@ describe('Switch - Behavior', () => {
     expect(button?.getAttribute('data-state')).toBe('unchecked');
   });
 
-  it('should preserves an explicit native button type and checked state hooks', () => {
+  it('should preserve an explicit native button type and checked state hooks', () => {
     container = mount(
       <Switch type="submit" checked>
         Publish
@@ -42,7 +42,7 @@ describe('Switch - Behavior', () => {
     expect(button?.getAttribute('data-state')).toBe('checked');
   });
 
-  it('should emits uncontrolled state changes through onCheckedChange', async () => {
+  it('should emit uncontrolled state changes through onCheckedChange', async () => {
     const onCheckedChange = vi.fn();
 
     container = mount(
@@ -62,7 +62,7 @@ describe('Switch - Behavior', () => {
     expect(onCheckedChange).toHaveBeenCalledWith(true);
   });
 
-  it('should calls onCheckedChange in controlled mode', () => {
+  it('should call onCheckedChange in controlled mode', () => {
     const onCheckedChange = vi.fn();
 
     container = mount(
@@ -76,7 +76,7 @@ describe('Switch - Behavior', () => {
     expect(onCheckedChange).toHaveBeenCalledWith(true);
   });
 
-  it('should renders hidden form input when named', () => {
+  it('should render hidden form input when named', () => {
     container = mount(
       <Switch name="notifications" defaultChecked value="enabled">
         Notifications
@@ -95,7 +95,7 @@ describe('Switch - Behavior', () => {
     expect(input?.checked).toBe(true);
   });
 
-  it('should keeps the hidden form input in sync after uncontrolled presses', async () => {
+  it('should keep the hidden form input in sync after uncontrolled presses', async () => {
     container = mount(
       <Switch name="notifications" defaultChecked={false}>
         Notifications
@@ -127,7 +127,7 @@ describe('Switch - Behavior', () => {
     expect(updatedInput?.checked).toBe(true);
   });
 
-  it('should supports asChild composition and merges host props', () => {
+  it('should support asChild composition and merge host props', () => {
     container = mount(
       <Switch
         asChild
@@ -149,7 +149,7 @@ describe('Switch - Behavior', () => {
     expect(host?.getAttribute('data-state')).toBe('checked');
   });
 
-  it('should toggles an asChild host with Enter and Space', async () => {
+  it('should toggle an asChild host with Enter and Space', async () => {
     const onCheckedChange = vi.fn();
     container = mount(
       <Switch asChild onCheckedChange={onCheckedChange}>
@@ -174,7 +174,7 @@ describe('Switch - Behavior', () => {
     expect(onCheckedChange.mock.calls).toEqual([[true], [false]]);
   });
 
-  it('should applies disabled semantics to asChild hosts', () => {
+  it('should apply disabled semantics to asChild hosts', () => {
     const onCheckedChange = vi.fn();
 
     container = mount(
@@ -195,7 +195,7 @@ describe('Switch - Behavior', () => {
     expect(onCheckedChange).not.toHaveBeenCalled();
   });
 
-  it('should forwards refs to native and asChild hosts', () => {
+  it('should forward refs to native and asChild hosts', () => {
     let nativeRef: HTMLButtonElement | null = null;
     let childRef: HTMLElement | null = null;
 

--- a/tests/browser/components/switch/determinism.test.tsx
+++ b/tests/browser/components/switch/determinism.test.tsx
@@ -4,7 +4,7 @@ import { expectDeterministicRender } from '../../determinism';
 import { mount, unmount } from '../../test-utils';
 
 describe('Switch - Determinism', () => {
-  it('should renders deterministic native switch markup', () => {
+  it('should render deterministic native switch markup', () => {
     expectDeterministicRender(() => (
       <Switch defaultChecked>Airplane mode</Switch>
     ));
@@ -15,7 +15,7 @@ describe('Switch - Determinism', () => {
     ));
   });
 
-  it('should renders deterministic asChild switch markup', () => {
+  it('should render deterministic asChild switch markup', () => {
     expectDeterministicRender(() => (
       <Switch asChild disabled>
         <div>Power</div>
@@ -23,7 +23,7 @@ describe('Switch - Determinism', () => {
     ));
   });
 
-  it('should keeps checked state props-driven across remounts', () => {
+  it('should keep checked state props-driven across remounts', () => {
     let container = mount(<Switch checked={false}>Power</Switch>);
 
     try {
@@ -43,7 +43,7 @@ describe('Switch - Determinism', () => {
     }
   });
 
-  it('should does not schedule timers during render', () => {
+  it('should not schedule timers during render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(<Switch>Power</Switch>);

--- a/tests/browser/components/table/a11y.test.tsx
+++ b/tests/browser/components/table/a11y.test.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../../../src/components/table';
 
 describe('Table - Accessibility', () => {
-  it('should has no automated axe violations for a semantic table', async () => {
+  it('should have no automated axe violations for a semantic table', async () => {
     await expectNoAxeViolations(
       <Table aria-label="Users">
         <TableCaption>Users</TableCaption>

--- a/tests/browser/components/table/behavior.test.tsx
+++ b/tests/browser/components/table/behavior.test.tsx
@@ -19,7 +19,7 @@ describe('Table - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders semantic table elements by default', async () => {
+  it('should render semantic table elements by default', async () => {
     container = mount(
       <Table aria-label="Users">
         <TableCaption>Users</TableCaption>
@@ -55,7 +55,7 @@ describe('Table - Behavior', () => {
     expect(container.querySelectorAll('td').length).toBe(3);
   });
 
-  it('should supports asChild composition on the root and cells', async () => {
+  it('should support asChild composition on the root and cells', async () => {
     container = mount(
       <Table asChild aria-label="Users">
         <table>
@@ -85,7 +85,7 @@ describe('Table - Behavior', () => {
     expect(cell?.textContent).toBe('Alice');
   });
 
-  it('should preserves caption and header data attributes for theming', async () => {
+  it('should preserve caption and header data attributes for theming', async () => {
     container = mount(
       <Table aria-label="Users">
         <TableCaption>Users</TableCaption>

--- a/tests/browser/components/textarea/a11y.test.tsx
+++ b/tests/browser/components/textarea/a11y.test.tsx
@@ -5,11 +5,11 @@ import { expectNoAxeViolations } from '../../accessibility';
 import { mount, unmount } from '../../test-utils';
 
 describe('Textarea - Accessibility', () => {
-  it('should has no automated axe violations for a labelled native textarea', async () => {
+  it('should have no automated axe violations for a labelled native textarea', async () => {
     await expectNoAxeViolations(<Textarea aria-label="Notes" rows={3} />);
   });
 
-  it('should has no automated axe violations for a labelled asChild textarea', async () => {
+  it('should have no automated axe violations for a labelled asChild textarea', async () => {
     await expectNoAxeViolations(
       <Textarea asChild>
         <textarea aria-label="Notes" rows={3} />
@@ -17,7 +17,7 @@ describe('Textarea - Accessibility', () => {
     );
   });
 
-  it('should uses native disabled semantics for the default host', () => {
+  it('should use native disabled semantics for the default host', () => {
     const container = mount(<Textarea aria-label="Notes" disabled />);
 
     try {
@@ -36,7 +36,7 @@ describe('Textarea - Accessibility', () => {
     }
   });
 
-  it('should uses native disabled semantics for disabled asChild textarea hosts', () => {
+  it('should use native disabled semantics for disabled asChild textarea hosts', () => {
     const container = mount(
       <Textarea asChild disabled>
         <textarea aria-label="Notes" />
@@ -57,7 +57,7 @@ describe('Textarea - Accessibility', () => {
     }
   });
 
-  it('should matches the documented textarea accessibility contract', () => {
+  it('should match the documented textarea accessibility contract', () => {
     expect(TEXTAREA_A11Y_CONTRACT.HOST_ELEMENT).toBe('textarea');
     expect(TEXTAREA_A11Y_CONTRACT.DISABLED_ATTRIBUTES).toEqual({
       native: 'disabled',

--- a/tests/browser/components/textarea/behavior.test.tsx
+++ b/tests/browser/components/textarea/behavior.test.tsx
@@ -10,7 +10,7 @@ describe('Textarea - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a native textarea by default', () => {
+  it('should render a native textarea by default', () => {
     container = mount(<Textarea rows={4}>Notes</Textarea>);
 
     const textarea = container.querySelector(
@@ -22,7 +22,7 @@ describe('Textarea - Behavior', () => {
     expect(textarea?.getAttribute('data-slot')).toBe('textarea');
   });
 
-  it('should applies disabled semantics to native textarea', () => {
+  it('should apply disabled semantics to native textarea', () => {
     container = mount(<Textarea disabled />);
 
     const textarea = container.querySelector(
@@ -34,7 +34,7 @@ describe('Textarea - Behavior', () => {
     expect(textarea?.getAttribute('data-disabled')).toBe('true');
   });
 
-  it('should preserves readonly semantics on native textareas', () => {
+  it('should preserve readonly semantics on native textareas', () => {
     container = mount(<Textarea readOnly>Locked notes</Textarea>);
 
     const textarea = container.querySelector(
@@ -45,7 +45,7 @@ describe('Textarea - Behavior', () => {
     expect(textarea?.hasAttribute('readonly')).toBe(true);
   });
 
-  it('should supports asChild composition and merges host props', () => {
+  it('should support asChild composition and merge host props', () => {
     container = mount(
       <Textarea asChild data-testid="custom-textarea" data-from-textarea="yes">
         <textarea aria-label="Notes" data-from-child="yes" />
@@ -62,7 +62,7 @@ describe('Textarea - Behavior', () => {
     expect(textarea?.getAttribute('data-slot')).toBe('textarea');
   });
 
-  it('should applies native disabled semantics to asChild textarea hosts', () => {
+  it('should apply native disabled semantics to asChild textarea hosts', () => {
     container = mount(
       <Textarea asChild disabled>
         <textarea aria-label="Notes" />
@@ -77,7 +77,7 @@ describe('Textarea - Behavior', () => {
     expect(host?.getAttribute('data-disabled')).toBe('true');
   });
 
-  it('should preserves readonly semantics on asChild textarea hosts', () => {
+  it('should preserve readonly semantics on asChild textarea hosts', () => {
     container = mount(
       <Textarea asChild readOnly>
         <textarea aria-label="Notes" />
@@ -92,7 +92,7 @@ describe('Textarea - Behavior', () => {
     expect(host?.hasAttribute('readonly')).toBe(true);
   });
 
-  it('should fails loudly when asChild does not receive a native textarea host', () => {
+  it('should fail loudly when asChild does not receive a native textarea host', () => {
     expect(() =>
       mount(
         <Textarea asChild>

--- a/tests/browser/components/textarea/determinism.test.tsx
+++ b/tests/browser/components/textarea/determinism.test.tsx
@@ -3,11 +3,11 @@ import { Textarea } from '../../../../src/components/textarea/textarea';
 import { expectDeterministicRender } from '../../determinism';
 
 describe('Textarea - Determinism', () => {
-  it('should renders deterministic native textarea markup', () => {
+  it('should render deterministic native textarea markup', () => {
     expectDeterministicRender(() => <Textarea rows={4}>Notes</Textarea>);
   });
 
-  it('should renders deterministic asChild textarea markup', () => {
+  it('should render deterministic asChild textarea markup', () => {
     expectDeterministicRender(() => (
       <Textarea asChild>
         <textarea aria-label="Notes">Custom notes</textarea>

--- a/tests/browser/components/toast/a11y.test.tsx
+++ b/tests/browser/components/toast/a11y.test.tsx
@@ -10,7 +10,7 @@ import {
 import { expectNoAxeViolations } from '../../accessibility';
 
 describe('Toast - Accessibility', () => {
-  it('should has no toast accessibility regressions', async () => {
+  it('should have no toast accessibility regressions', async () => {
     await expectNoAxeViolations(
       <ToastHost>
         <ToastViewport />

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -168,7 +168,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
-  it('should renders toast content inside the viewport in declaration order', async () => {
+  it('should render toast content inside the viewport in declaration order', async () => {
     container = mount(
       <ToastHost>
         <ToastViewport />
@@ -189,7 +189,7 @@ describe('Toast - Behavior', () => {
     expect(titles).toEqual(['First', 'Second']);
   });
 
-  it('should dismisses toasts on their configured timer', async () => {
+  it('should dismiss toasts on their configured timer', async () => {
     vi.useFakeTimers();
     container = mount(
       <ToastHost duration={50}>
@@ -210,7 +210,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
-  it('should dismisses multiple open toasts when timers expire at the same time', async () => {
+  it('should dismiss multiple open toasts when timers expire at the same time', async () => {
     vi.useFakeTimers();
     container = mount(
       <ToastHost duration={40}>
@@ -233,7 +233,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(0);
   });
 
-  it('should restores focus after closing a controlled toast', async () => {
+  it('should restore focus after closing a controlled toast', async () => {
     container = mount(<ControlledToastFixture />);
 
     const launcher = container.querySelector('#launcher') as HTMLButtonElement;
@@ -278,7 +278,7 @@ describe('Toast - Behavior', () => {
     expect(document.activeElement).toBe(elsewhere);
   });
 
-  it('should opens a controlled toast from a user action without locking the page', async () => {
+  it('should open a controlled toast from a user action without locking the page', async () => {
     container = mount(<ControlledToastOpenerFixture />);
     await flushUpdates();
 
@@ -302,7 +302,7 @@ describe('Toast - Behavior', () => {
     expect(action.getAttribute('href')).toBe('/logs');
   });
 
-  it('should opens a controlled toast with a link action without locking the page', async () => {
+  it('should open a controlled toast with a link action without locking the page', async () => {
     container = mount(<ControlledToastLinkActionFixture />);
     await flushUpdates();
 
@@ -324,7 +324,7 @@ describe('Toast - Behavior', () => {
     expect(action.getAttribute('href')).toBe('/logs');
   });
 
-  it('should opens a controlled toast from a press button without locking the page', async () => {
+  it('should open a controlled toast from a press button without locking the page', async () => {
     container = mount(<ControlledToastPressButtonFixture />);
     await flushUpdates();
 
@@ -340,7 +340,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelector('[data-toast="true"]')).not.toBeNull();
   });
 
-  it('should dismisses on escape and action press', async () => {
+  it('should dismiss on escape and action press', async () => {
     container = mount(
       <ToastHost>
         <ToastViewport />
@@ -380,7 +380,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
-  it('should dismisses asChild actions and close controls with Enter and Space', async () => {
+  it('should dismiss asChild actions and close controls with Enter and Space', async () => {
     container = mount(
       <ToastHost duration={60_000}>
         <ToastViewport />
@@ -425,7 +425,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
-  it('should preserves action styling and href when composed with a link child', async () => {
+  it('should preserve action styling and href when composed with a link child', async () => {
     container = mount(
       <ToastHost>
         <ToastViewport />

--- a/tests/browser/components/toast/determinism.test.tsx
+++ b/tests/browser/components/toast/determinism.test.tsx
@@ -8,7 +8,7 @@ import {
 import { expectDeterministicRender } from '../../determinism';
 
 describe('Toast - Determinism', () => {
-  it('should renders deterministic toast markup', () => {
+  it('should render deterministic toast markup', () => {
     expectDeterministicRender(() => (
       <ToastHost>
         <ToastViewport />

--- a/tests/browser/components/toggle-group/a11y.test.tsx
+++ b/tests/browser/components/toggle-group/a11y.test.tsx
@@ -8,7 +8,7 @@ import { mount, unmount } from '../../test-utils';
 import { TOGGLE_GROUP_A11Y_CONTRACT } from '../../../../src/components/toggle-group/toggle-group.a11y';
 
 describe('ToggleGroup - Accessibility', () => {
-  it('should has no automated axe violations for native toggle group items', async () => {
+  it('should have no automated axe violations for native toggle group items', async () => {
     await expectNoAxeViolations(
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -17,7 +17,7 @@ describe('ToggleGroup - Accessibility', () => {
     );
   });
 
-  it('should has no automated axe violations for labelled asChild items', async () => {
+  it('should have no automated axe violations for labelled asChild items', async () => {
     await expectNoAxeViolations(
       <ToggleGroup aria-label="Text alignment" defaultValue="left">
         <ToggleGroupItem asChild value="left">
@@ -30,7 +30,7 @@ describe('ToggleGroup - Accessibility', () => {
     );
   });
 
-  it('should uses group semantics and pressed state for native items', () => {
+  it('should use group semantics and pressed state for native items', () => {
     const container = mount(
       <ToggleGroup aria-label="Text alignment" defaultValue="left">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -57,7 +57,7 @@ describe('ToggleGroup - Accessibility', () => {
     }
   });
 
-  it('should uses button semantics for asChild items', () => {
+  it('should use button semantics for asChild items', () => {
     const container = mount(
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem asChild value="left">
@@ -78,7 +78,7 @@ describe('ToggleGroup - Accessibility', () => {
     }
   });
 
-  it('should uses disabled semantics for asChild items without native button support', () => {
+  it('should use disabled semantics for asChild items without native button support', () => {
     const container = mount(
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem asChild value="left" disabled>
@@ -97,7 +97,7 @@ describe('ToggleGroup - Accessibility', () => {
     }
   });
 
-  it('should matches the documented toggle group accessibility contract', () => {
+  it('should match the documented toggle group accessibility contract', () => {
     expect(TOGGLE_GROUP_A11Y_CONTRACT).toEqual({
       GROUP_ROLE: 'group',
       ITEM_ROLE: 'button',

--- a/tests/browser/components/toggle-group/behavior.test.tsx
+++ b/tests/browser/components/toggle-group/behavior.test.tsx
@@ -28,7 +28,7 @@ describe('ToggleGroup - Behavior', () => {
     container = undefined;
   });
 
-  it('should mounts single and multiple toggle groups without render-time state errors', () => {
+  it('should mount single and multiple toggle groups without render-time state errors', () => {
     expect(() => {
       container = mount(
         <div>
@@ -47,7 +47,7 @@ describe('ToggleGroup - Behavior', () => {
     ).toHaveLength(2);
   });
 
-  it('should renders the group container and pressed hooks for single selection', () => {
+  it('should render the group container and pressed hooks for single selection', () => {
     container = mount(
       <ToggleGroup defaultValue="left" orientation="vertical">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -69,7 +69,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(right.getAttribute('data-state')).toBe('off');
   });
 
-  it('should updates uncontrolled single selection and allows collapsing the active item', async () => {
+  it('should update uncontrolled single selection and allow collapsing the active item', async () => {
     container = mount(
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -98,7 +98,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(right.getAttribute('aria-pressed')).toBe('false');
   });
 
-  it('should updates uncontrolled multiple selection independently', async () => {
+  it('should update uncontrolled multiple selection independently', async () => {
     container = mount(
       <ToggleGroup type="multiple" defaultValue={['left']}>
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -127,7 +127,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(right.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('should supports nested toggle items without relying on direct child injection', async () => {
+  it('should support nested toggle items without relying on direct child injection', async () => {
     container = mount(
       <ToggleGroup defaultValue="left">
         <div>
@@ -228,7 +228,7 @@ describe('ToggleGroup - Behavior', () => {
     }).toThrow('ToggleGroup components must be used within <ToggleGroup>');
   });
 
-  it('should emits normalized values for single and multiple groups', async () => {
+  it('should emit normalized values for single and multiple groups', async () => {
     const onSingleValueChange = vi.fn();
     const onMultipleValueChange = vi.fn();
 
@@ -266,7 +266,7 @@ describe('ToggleGroup - Behavior', () => {
     ]);
   });
 
-  it('should blocks interaction when the group or item is disabled', async () => {
+  it('should block interaction when the group or item is disabled', async () => {
     const onGroupValueChange = vi.fn();
     const onItemValueChange = vi.fn();
 
@@ -310,7 +310,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(itemRight.getAttribute('aria-pressed')).toBe('true');
   });
 
-  it('should supports asChild item composition and merges host props', () => {
+  it('should support asChild item composition and merge host props', () => {
     container = mount(
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem
@@ -335,7 +335,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(host.getAttribute('data-state')).toBe('on');
   });
 
-  it('should toggles an asChild item with Enter and Space', async () => {
+  it('should toggle an asChild item with Enter and Space', async () => {
     container = mount(
       <ToggleGroup>
         <ToggleGroupItem asChild value="left">
@@ -362,7 +362,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(item.getAttribute('aria-pressed')).toBe('false');
   });
 
-  it('should forwards refs to the group container and item hosts', () => {
+  it('should forward refs to the group container and item hosts', () => {
     let groupRef: HTMLDivElement | null = null;
     let nativeItemRef: HTMLButtonElement | null = null;
     let childItemRef: HTMLElement | null = null;
@@ -399,7 +399,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(childItemRef).toBe(childHost);
   });
 
-  it('should treats value as controlled state when provided', async () => {
+  it('should treat value as controlled state when provided', async () => {
     const onValueChange = vi.fn();
 
     container = mount(
@@ -423,7 +423,7 @@ describe('ToggleGroup - Behavior', () => {
     ).toBe('false');
   });
 
-  it('should does not wrap roving focus at boundaries when loop is false', async () => {
+  it('should not wrap roving focus at boundaries when loop is false', async () => {
     container = mount(
       <ToggleGroup defaultValue="left" orientation="horizontal" loop={false}>
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -441,7 +441,7 @@ describe('ToggleGroup - Behavior', () => {
     expect(document.activeElement).toBe(getToggleByText(container, 'Left'));
   });
 
-  it('should does not activate disabled items during roving keyboard navigation attempts', async () => {
+  it('should not activate disabled items during roving keyboard navigation attempts', async () => {
     container = mount(
       <ToggleGroup defaultValue="left" orientation="vertical">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>

--- a/tests/browser/components/toggle-group/determinism.test.tsx
+++ b/tests/browser/components/toggle-group/determinism.test.tsx
@@ -7,7 +7,7 @@ import { expectDeterministicRender } from '../../determinism';
 import { mount, unmount } from '../../test-utils';
 
 describe('ToggleGroup - Determinism', () => {
-  it('should renders deterministic single and multiple toggle group markup', () => {
+  it('should render deterministic single and multiple toggle group markup', () => {
     expectDeterministicRender(() => (
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -22,7 +22,7 @@ describe('ToggleGroup - Determinism', () => {
     ));
   });
 
-  it('should renders deterministic asChild item markup', () => {
+  it('should render deterministic asChild item markup', () => {
     expectDeterministicRender(() => (
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem asChild value="left">
@@ -32,7 +32,7 @@ describe('ToggleGroup - Determinism', () => {
     ));
   });
 
-  it('should keeps selection props-driven across remounts', () => {
+  it('should keep selection props-driven across remounts', () => {
     let container = mount(
       <ToggleGroup defaultValue="left">
         <ToggleGroupItem value="left">Left</ToggleGroupItem>
@@ -74,7 +74,7 @@ describe('ToggleGroup - Determinism', () => {
     }
   });
 
-  it('should does not schedule timers during render', () => {
+  it('should not schedule timers during render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(

--- a/tests/browser/components/toggle/a11y.test.tsx
+++ b/tests/browser/components/toggle/a11y.test.tsx
@@ -5,11 +5,11 @@ import { mount, unmount } from '../../test-utils';
 import { TOGGLE_A11Y_CONTRACT } from '../../../../src/components/toggle/toggle.a11y';
 
 describe('Toggle - Accessibility', () => {
-  it('should has no automated axe violations for the native toggle path', async () => {
+  it('should have no automated axe violations for the native toggle path', async () => {
     await expectNoAxeViolations(<Toggle>Mute</Toggle>);
   });
 
-  it('should has no automated axe violations for labelled asChild composition', async () => {
+  it('should have no automated axe violations for labelled asChild composition', async () => {
     await expectNoAxeViolations(
       <Toggle asChild>
         <span>Mute</span>
@@ -17,7 +17,7 @@ describe('Toggle - Accessibility', () => {
     );
   });
 
-  it('should uses implicit native button semantics for the default host', () => {
+  it('should use implicit native button semantics for the default host', () => {
     const container = mount(<Toggle pressed={false}>Mute</Toggle>);
 
     try {
@@ -30,7 +30,7 @@ describe('Toggle - Accessibility', () => {
     }
   });
 
-  it('should uses button semantics when composed with asChild', () => {
+  it('should use button semantics when composed with asChild', () => {
     const container = mount(
       <Toggle asChild pressed>
         <span>Mute</span>
@@ -49,7 +49,7 @@ describe('Toggle - Accessibility', () => {
     }
   });
 
-  it('should uses native disabled semantics for the default host', () => {
+  it('should use native disabled semantics for the default host', () => {
     const container = mount(<Toggle disabled>Mute</Toggle>);
 
     try {
@@ -62,7 +62,7 @@ describe('Toggle - Accessibility', () => {
     }
   });
 
-  it('should uses aria-disabled and removes disabled asChild hosts from tab order', () => {
+  it('should use aria-disabled and remove disabled asChild hosts from tab order', () => {
     const container = mount(
       <Toggle asChild disabled>
         <span>Mute</span>
@@ -79,7 +79,7 @@ describe('Toggle - Accessibility', () => {
     }
   });
 
-  it('should preserves accessible naming props from the host', () => {
+  it('should preserve accessible naming props from the host', () => {
     const container = mount(
       <div>
         <span id="toggle-label">Mute audio</span>
@@ -96,7 +96,7 @@ describe('Toggle - Accessibility', () => {
     }
   });
 
-  it('should matches the documented toggle accessibility contract', () => {
+  it('should match the documented toggle accessibility contract', () => {
     expect(TOGGLE_A11Y_CONTRACT.ROLE).toBe('button');
     expect(TOGGLE_A11Y_CONTRACT.KEYBOARD_ACTIVATION).toEqual([
       'Enter',

--- a/tests/browser/components/toggle/behavior.test.tsx
+++ b/tests/browser/components/toggle/behavior.test.tsx
@@ -11,7 +11,7 @@ describe('Toggle - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a native toggle button by default', () => {
+  it('should render a native toggle button by default', () => {
     container = mount(<Toggle>Mute</Toggle>);
     const button = container.querySelector(
       'button'
@@ -25,7 +25,7 @@ describe('Toggle - Behavior', () => {
     expect(button?.getAttribute('data-state')).toBe('off');
   });
 
-  it('should preserves an explicit native button type and pressed hooks', () => {
+  it('should preserve an explicit native button type and pressed hooks', () => {
     container = mount(
       <Toggle type="submit" pressed>
         Save
@@ -40,7 +40,7 @@ describe('Toggle - Behavior', () => {
     expect(button?.getAttribute('data-state')).toBe('on');
   });
 
-  it('should invokes onPress exactly once per native click', () => {
+  it('should invoke onPress exactly once per native click', () => {
     const onPress = vi.fn();
 
     container = mount(<Toggle onPress={onPress}>Mute</Toggle>);
@@ -53,7 +53,7 @@ describe('Toggle - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should blocks native interaction when disabled', () => {
+  it('should block native interaction when disabled', () => {
     const onPress = vi.fn();
 
     container = mount(
@@ -73,7 +73,7 @@ describe('Toggle - Behavior', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
-  it('should supports asChild composition and merges host props', () => {
+  it('should support asChild composition and merge host props', () => {
     container = mount(
       <Toggle
         asChild
@@ -95,7 +95,7 @@ describe('Toggle - Behavior', () => {
     expect(host?.getAttribute('data-slot')).toBe('toggle');
   });
 
-  it('should routes interaction through the asChild host element', () => {
+  it('should route interaction through the asChild host element', () => {
     const onPress = vi.fn();
 
     container = mount(
@@ -112,7 +112,7 @@ describe('Toggle - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
-  it('should activates an asChild host with Enter and Space', async () => {
+  it('should activate an asChild host with Enter and Space', async () => {
     const onPress = vi.fn();
     container = mount(
       <Toggle asChild onPress={onPress}>
@@ -129,7 +129,7 @@ describe('Toggle - Behavior', () => {
     expect(onPress).toHaveBeenCalledTimes(2);
   });
 
-  it('should applies disabled semantics to asChild hosts', () => {
+  it('should apply disabled semantics to asChild hosts', () => {
     const onPress = vi.fn();
 
     container = mount(
@@ -150,7 +150,7 @@ describe('Toggle - Behavior', () => {
     expect(onPress).not.toHaveBeenCalled();
   });
 
-  it('should forwards refs to native and asChild hosts', () => {
+  it('should forward refs to native and asChild hosts', () => {
     let nativeRef: HTMLButtonElement | null = null;
     let childRef: HTMLElement | null = null;
 

--- a/tests/browser/components/toggle/determinism.test.tsx
+++ b/tests/browser/components/toggle/determinism.test.tsx
@@ -4,7 +4,7 @@ import { expectDeterministicRender } from '../../determinism';
 import { mount, unmount } from '../../test-utils';
 
 describe('Toggle - Determinism', () => {
-  it('should renders deterministic native toggle markup', () => {
+  it('should render deterministic native toggle markup', () => {
     expectDeterministicRender(() => <Toggle>Mute</Toggle>);
     expectDeterministicRender(() => (
       <Toggle pressed type="submit">
@@ -13,7 +13,7 @@ describe('Toggle - Determinism', () => {
     ));
   });
 
-  it('should renders deterministic asChild toggle markup', () => {
+  it('should render deterministic asChild toggle markup', () => {
     expectDeterministicRender(() => (
       <Toggle asChild pressed>
         <span>Mute</span>
@@ -21,7 +21,7 @@ describe('Toggle - Determinism', () => {
     ));
   });
 
-  it('should keeps pressed state props-driven across remounts', () => {
+  it('should keep pressed state props-driven across remounts', () => {
     let container = mount(<Toggle pressed={false}>Mute</Toggle>);
 
     try {
@@ -41,7 +41,7 @@ describe('Toggle - Determinism', () => {
     }
   });
 
-  it('should does not schedule timers during render', () => {
+  it('should not schedule timers during render', () => {
     const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const container = mount(<Toggle>Mute</Toggle>);

--- a/tests/browser/components/tooltip/behavior.test.tsx
+++ b/tests/browser/components/tooltip/behavior.test.tsx
@@ -15,7 +15,7 @@ describe('Tooltip - Behavior', () => {
     unmount(container);
   });
 
-  it('should updates trigger state around focus events', async () => {
+  it('should update trigger state around focus events', async () => {
     container = mount(
       <Tooltip>
         <TooltipTrigger>Hover me</TooltipTrigger>
@@ -39,7 +39,7 @@ describe('Tooltip - Behavior', () => {
     expect(trigger.getAttribute('data-state')).toBe('closed');
   });
 
-  it('should keeps custom content positioning through the post-open portal sync', async () => {
+  it('should keep custom content positioning through the post-open portal sync', async () => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation(
       (callback: FrameRequestCallback) => {
         callback(0);

--- a/tests/browser/components/virtual-list/a11y.test.tsx
+++ b/tests/browser/components/virtual-list/a11y.test.tsx
@@ -14,7 +14,7 @@ const items: Item[] = [
 ];
 
 describe('VirtualList - Accessibility', () => {
-  it('should has no automated axe violations for a semantic virtual list', async () => {
+  it('should have no automated axe violations for a semantic virtual list', async () => {
     await expectNoAxeViolations(
       <VirtualList
         aria-label="Items"

--- a/tests/browser/components/virtual-list/behavior.test.tsx
+++ b/tests/browser/components/virtual-list/behavior.test.tsx
@@ -26,7 +26,7 @@ describe('VirtualList - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a virtual window, scrolls by index, and follows the bottom', async () => {
+  it('should render a virtual window, scroll by index, and follow the bottom', async () => {
     let api: VirtualListApi<Item> | null = null;
     let appendItem: (() => void) | undefined;
 
@@ -98,7 +98,7 @@ describe('VirtualList - Behavior', () => {
     expect(container.querySelector('[data-key="item-8"]')).toBeTruthy();
   });
 
-  it('should maps typed viewport affordance to a stable data attribute', async () => {
+  it('should map typed viewport affordance to a stable data attribute', async () => {
     container = mount(
       <VirtualList
         aria-label="Messages"
@@ -119,7 +119,7 @@ describe('VirtualList - Behavior', () => {
     ).toBe('lg');
   });
 
-  it('should supports asChild composition with semantic list items', async () => {
+  it('should support asChild composition with semantic list items', async () => {
     container = mount(
       <VirtualList
         asChild

--- a/tests/browser/components/virtual-list/determinism.test.tsx
+++ b/tests/browser/components/virtual-list/determinism.test.tsx
@@ -14,7 +14,7 @@ const items: Item[] = [
 ];
 
 describe('VirtualList - Determinism', () => {
-  it('should renders deterministic virtual list markup', () => {
+  it('should render deterministic virtual list markup', () => {
     vi.useFakeTimers();
 
     try {

--- a/tests/browser/components/virtual-table/a11y.test.tsx
+++ b/tests/browser/components/virtual-table/a11y.test.tsx
@@ -28,7 +28,7 @@ const columns = [
 ] as const;
 
 describe('VirtualTable - Accessibility', () => {
-  it('should has no automated axe violations for a semantic virtual table', async () => {
+  it('should have no automated axe violations for a semantic virtual table', async () => {
     await expectNoAxeViolations(
       <VirtualTable
         aria-label="Users"

--- a/tests/browser/components/virtual-table/behavior.test.tsx
+++ b/tests/browser/components/virtual-table/behavior.test.tsx
@@ -41,7 +41,7 @@ describe('VirtualTable - Behavior', () => {
     container = undefined;
   });
 
-  it('should renders a sticky-headed virtual table and supports keyboard selection', async () => {
+  it('should render a sticky-headed virtual table and support keyboard selection', async () => {
     const onRowClick = vi.fn();
     let api: VirtualTableApi<Row> | null = null;
 
@@ -102,7 +102,7 @@ describe('VirtualTable - Behavior', () => {
     expect(container.querySelector('[data-row-key="row-9"]')).toBeTruthy();
   });
 
-  it('should maps typed viewport and table width affordances to stable data attributes', async () => {
+  it('should map typed viewport and table width affordances to stable data attributes', async () => {
     container = mount(
       <VirtualTable
         aria-label="Users"
@@ -124,7 +124,7 @@ describe('VirtualTable - Behavior', () => {
     expect(table?.getAttribute('data-table-width')).toBe('compact');
   });
 
-  it('should supports asChild composition on the wrapper host', async () => {
+  it('should support asChild composition on the wrapper host', async () => {
     container = mount(
       <VirtualTable
         asChild

--- a/tests/browser/components/virtual-table/determinism.test.tsx
+++ b/tests/browser/components/virtual-table/determinism.test.tsx
@@ -28,7 +28,7 @@ const columns = [
 ] as const;
 
 describe('VirtualTable - Determinism', () => {
-  it('should renders deterministic virtual table markup', () => {
+  it('should render deterministic virtual table markup', () => {
     vi.useFakeTimers();
 
     try {

--- a/tests/browser/components/visually-hidden/behavior.test.tsx
+++ b/tests/browser/components/visually-hidden/behavior.test.tsx
@@ -27,14 +27,14 @@ describe('VisuallyHidden — Behavior', () => {
     }
   });
 
-  it('should renders a hidden span by default', () => {
+  it('should render a hidden span by default', () => {
     container = mount(<VisuallyHidden>Hidden text</VisuallyHidden>);
     const span = container.querySelector('span');
     expect(span?.textContent).toBe('Hidden text');
     expect(span?.getAttribute('data-askr-visually-hidden')).toBe('true');
   });
 
-  it('should supports asChild composition', () => {
+  it('should support asChild composition', () => {
     container = mount(
       <VisuallyHidden asChild>
         <strong>Hidden</strong>

--- a/tests/jsdom/components/button/jsdom.test.tsx
+++ b/tests/jsdom/components/button/jsdom.test.tsx
@@ -68,11 +68,11 @@ describe('Button - jsdom regression', () => {
     expect(button?.querySelector('svg')?.getAttribute('data-icon')).toBe('sun');
   }
 
-  it('should replaces a stateful icon child instead of accumulating icons in source', async () => {
+  it('should replace a stateful icon child instead of accumulating icons in source', async () => {
     await expectSingleIconAcrossToggles(Button);
   });
 
-  it('should replaces a stateful icon child instead of accumulating icons in dist', async () => {
+  it('should replace a stateful icon child instead of accumulating icons in dist', async () => {
     await expectSingleIconAcrossToggles(DistButton);
   });
 

--- a/tests/jsdom/components/consistency-reset/internal-props.test.tsx
+++ b/tests/jsdom/components/consistency-reset/internal-props.test.tsx
@@ -37,7 +37,7 @@ describe('Consistency Reset - Internal Props', () => {
     unmount(container);
   });
 
-  it('should does not forward __* injected props to menubar DOM nodes', async () => {
+  it('should not forward __* injected props to menubar DOM nodes', async () => {
     container = mount(
       <Menubar>
         <MenubarMenu value="file">

--- a/tests/jsdom/components/consistency-reset/portal-contract.test.tsx
+++ b/tests/jsdom/components/consistency-reset/portal-contract.test.tsx
@@ -50,7 +50,7 @@ describe('Consistency Reset - Portal Contract', () => {
     unmount(container);
   });
 
-  it('should renders retained portal content at the root sink instead of inline', async () => {
+  it('should render retained portal content at the root sink instead of inline', async () => {
     container = mount(
       <div>
         <Dialog key="dialog" defaultOpen>
@@ -109,7 +109,7 @@ describe('Consistency Reset - Portal Contract', () => {
     expect(text.indexOf('Choose one')).toBeLessThan(text.lastIndexOf('Askr'));
   });
 
-  it('should registers dialog titles and descriptions without render-time state writes', async () => {
+  it('should register dialog titles and descriptions without render-time state writes', async () => {
     container = mount(
       <div>
         <Dialog key="dialog" defaultOpen>

--- a/tests/jsdom/components/icon/behavior.test.tsx
+++ b/tests/jsdom/components/icon/behavior.test.tsx
@@ -10,7 +10,7 @@ describe('IconBase', () => {
     container = undefined;
   });
 
-  it('should emits the canonical icon theme hooks', () => {
+  it('should emit the canonical icon theme hooks', () => {
     container = mount(IconBase({ iconName: 'Search' }));
 
     const svg = container.querySelector('svg')!;
@@ -19,7 +19,7 @@ describe('IconBase', () => {
     expect(svg.getAttribute('data-color')).toBe('current');
   });
 
-  it('should emits semantic data-size only for named sizes', () => {
+  it('should emit semantic data-size only for named sizes', () => {
     container = mount(IconBase({ size: 'sm' }));
 
     const svg = container.querySelector('svg')!;
@@ -29,7 +29,7 @@ describe('IconBase', () => {
     );
   });
 
-  it('should treats raw CSS sizes as consumer overrides', () => {
+  it('should treat raw CSS sizes as consumer overrides', () => {
     container = mount(IconBase({ size: '1.5rem' }));
 
     const svg = container.querySelector('svg')!;
@@ -37,7 +37,7 @@ describe('IconBase', () => {
     expect(svg.style.getPropertyValue('--ak-icon-size').trim()).toBe('1.5rem');
   });
 
-  it('should marks unlabeled icons as decorative', () => {
+  it('should mark unlabeled icons as decorative', () => {
     container = mount(IconBase({}));
 
     const svg = container.querySelector('svg')!;
@@ -45,7 +45,7 @@ describe('IconBase', () => {
     expect(svg.getAttribute('data-decorative')).toBe('true');
   });
 
-  it('should renders a title for labeled icons', () => {
+  it('should render a title for labeled icons', () => {
     container = mount(IconBase({ title: 'Search' }));
 
     const svg = container.querySelector('svg')!;
@@ -54,7 +54,7 @@ describe('IconBase', () => {
     expect(svg.querySelector('title')?.textContent).toBe('Search');
   });
 
-  it('should preserves explicit stroke width overrides', () => {
+  it('should preserve explicit stroke width overrides', () => {
     container = mount(IconBase({ strokeWidth: 1.5 }));
 
     const svg = container.querySelector('svg')!;
@@ -63,7 +63,7 @@ describe('IconBase', () => {
     );
   });
 
-  it('should pins intrinsic svg sizing while exposing css size hooks', () => {
+  it('should pin intrinsic svg sizing while exposing css size hooks', () => {
     container = mount(IconBase({ size: 15 }));
 
     const svg = container.querySelector('svg')!;

--- a/tests/unit/bench-contract.test.ts
+++ b/tests/unit/bench-contract.test.ts
@@ -29,7 +29,7 @@ function readBenchFiles() {
 }
 
 describe('Bench contract', () => {
-  it('should covers the public component surface with benchmark entries', () => {
+  it('should cover the public component surface with benchmark entries', () => {
     const benchFiles = readBenchFiles();
     const tier3BenchFiles = readdirSync(
       join(process.cwd(), 'benches', 'tier3'),

--- a/tests/unit/browser-bench-contract.test.ts
+++ b/tests/unit/browser-bench-contract.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 
 describe('Browser bench contract', () => {
-  it('should keeps the tier4 browser benchmark files aligned with the browser bench contract', () => {
+  it('should keep the tier4 browser benchmark files aligned with the browser bench contract', () => {
     const tier3BrowserBenchFiles = readdirSync(
       join(process.cwd(), 'benches', 'tier3'),
       {

--- a/tests/unit/docs-contract.test.ts
+++ b/tests/unit/docs-contract.test.ts
@@ -79,7 +79,7 @@ describe('Docs contract', () => {
     }
   });
 
-  it('should keeps the documented component names aligned with the published surface', () => {
+  it('should keep the documented component names aligned with the published surface', () => {
     const docs = [
       'README.md',
       'askr-ui.md',

--- a/tests/unit/export-map.test.ts
+++ b/tests/unit/export-map.test.ts
@@ -33,7 +33,7 @@ function readPackageJson(): PackageJson {
 }
 
 describe('Package exports', () => {
-  it('should publishes the curated root and direct component entrypoints only', () => {
+  it('should publish the curated root and direct component entrypoints only', () => {
     const packageJson = readPackageJson();
 
     expectExportTarget(

--- a/tests/unit/foundations-contract.test.ts
+++ b/tests/unit/foundations-contract.test.ts
@@ -23,7 +23,7 @@ function walkSourceFiles(dir: string): string[] {
 }
 
 describe('Foundations contract', () => {
-  it('should keeps the legacy local foundations entrypoint out of the package', () => {
+  it('should keep the legacy local foundations entrypoint out of the package', () => {
     const packageJson = JSON.parse(
       readFileSync(join(process.cwd(), 'package.json'), 'utf8')
     ) as { exports: Record<string, unknown> };

--- a/tests/unit/public-api.test.ts
+++ b/tests/unit/public-api.test.ts
@@ -11,7 +11,7 @@ function isPublicValueExport(name: string) {
 }
 
 describe('Public API', () => {
-  it('should matches the manifest-driven surface from the root entrypoint', () => {
+  it('should match the manifest-driven surface from the root entrypoint', () => {
     const sourceExportNames = Array.from(
       new Set(
         componentSurface.flatMap((entry) =>

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -13,7 +13,7 @@ function readComponentDirectories() {
 }
 
 describe('Source layout', () => {
-  it('should keeps the component tree flat and one folder per public component', () => {
+  it('should keep the component tree flat and one folder per public component', () => {
     const expectedDirectories = [
       ...componentSurface.map((entry) => entry.name),
       '_internal',


### PR DESCRIPTION
Summary

- Refresh Node type definitions through askr upgrade.

Local verification

- npm ci
- npm audit --audit-level=moderate
- npm run check