### PR TITLE
fix: isolate composite identity and repair roving focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/_internal/composite.ts
+++ b/src/components/_internal/composite.ts
@@ -1,3 +1,4 @@
+import { getSignal, state } from '@askrjs/askr';
 import { createCollection } from '@askrjs/askr/foundations/structures';
 
 export type CompositeCollectionMetadata = {
@@ -23,6 +24,55 @@ const compositeRegistrations = new Map<
     unregister: () => void;
   }
 >();
+const compositeObservers = new WeakMap<
+  ReturnType<typeof createCollection<HTMLElement, CompositeCollectionMetadata>>,
+  Map<
+    AbortSignal,
+    {
+      notify: () => void;
+      queued: boolean;
+      snapshot: Array<{
+        metadata: CompositeCollectionMetadata;
+        node: HTMLElement;
+      }>;
+    }
+  >
+>();
+
+function getCompositeSnapshot(
+  collection: ReturnType<
+    typeof createCollection<HTMLElement, CompositeCollectionMetadata>
+  >
+) {
+  return collection
+    .items()
+    .slice()
+    .sort((left, right) => left.metadata.index - right.metadata.index);
+}
+
+function isSameCompositeSnapshot(
+  left: ReturnType<typeof getCompositeSnapshot>,
+  right: ReturnType<typeof getCompositeSnapshot>
+) {
+  return (
+    left.length === right.length &&
+    left.every(
+      (item, index) =>
+        item.node === right[index]?.node &&
+        isSameCompositeMetadata(item.metadata, right[index]!.metadata)
+    )
+  );
+}
+
+function notifyCompositeObservers(
+  collection: ReturnType<
+    typeof createCollection<HTMLElement, CompositeCollectionMetadata>
+  >
+) {
+  for (const observer of compositeObservers.get(collection)?.values() ?? []) {
+    observer.notify();
+  }
+}
 
 export function getCompositeCollection(id: string) {
   const existing = compositeCollections.get(id);
@@ -34,6 +84,65 @@ export function getCompositeCollection(id: string) {
   const created = createCollection<HTMLElement, CompositeCollectionMetadata>();
   compositeCollections.set(id, created);
   return created;
+}
+
+export function observeCompositeCollection(id: string) {
+  const collection = getCompositeCollection(id);
+  const version = state(0);
+  version();
+  const signal = getSignal();
+  const observers = compositeObservers.get(collection) ?? new Map();
+  const existing = observers.get(signal);
+
+  if (existing) {
+    existing.snapshot = getCompositeSnapshot(collection);
+  }
+
+  if (!observers.has(signal)) {
+    const observer = {
+      queued: false,
+      snapshot: getCompositeSnapshot(collection),
+      notify: () => {},
+    };
+    observer.notify = () => {
+      if (observer.queued) {
+        return;
+      }
+
+      observer.queued = true;
+      queueMicrotask(() => {
+        observer.queued = false;
+
+        if (signal.aborted) {
+          return;
+        }
+
+        const nextSnapshot = getCompositeSnapshot(collection);
+
+        if (isSameCompositeSnapshot(observer.snapshot, nextSnapshot)) {
+          return;
+        }
+
+        observer.snapshot = nextSnapshot;
+        version.set((current) => current + 1);
+      });
+    };
+    observers.set(signal, observer);
+    compositeObservers.set(collection, observers);
+    signal.addEventListener(
+      'abort',
+      () => {
+        observers.delete(signal);
+
+        if (observers.size === 0) {
+          compositeObservers.delete(collection);
+        }
+      },
+      { once: true }
+    );
+  }
+
+  return collection;
 }
 
 export function getCompositeCollectionItems(
@@ -76,6 +185,9 @@ export function registerCompositeNode(
     }
     existing?.unregister();
     compositeRegistrations.delete(key);
+    if (existing) {
+      notifyCompositeObservers(existing.collection);
+    }
     return Boolean(existing);
   }
 
@@ -103,6 +215,7 @@ export function registerCompositeNode(
     owner,
     unregister,
   });
+  notifyCompositeObservers(collection);
 
   return true;
 }

--- a/src/components/_internal/focus.ts
+++ b/src/components/_internal/focus.ts
@@ -331,3 +331,140 @@ export function restorePendingCollectionItemFocus(
     pendingFocus.index = null;
   }
 }
+
+export type CompositeItemFocusTracker = {
+  disabled: boolean;
+  focused: boolean;
+  repairQueued: boolean;
+};
+
+const compositeItemFocusTrackers = new WeakMap<
+  HTMLElement,
+  CompositeItemFocusTracker
+>();
+
+function getCompositeItemFocusTracker(
+  node: HTMLElement
+): CompositeItemFocusTracker {
+  const existing = compositeItemFocusTrackers.get(node);
+
+  if (existing) {
+    return existing;
+  }
+
+  const created = {
+    disabled: false,
+    focused: false,
+    repairQueued: false,
+  };
+  compositeItemFocusTrackers.set(node, created);
+  return created;
+}
+
+export function compositeItemFocusProps(): {
+  onBlur: (event: FocusEvent) => void;
+  onFocus: (event: FocusEvent) => void;
+} {
+  return {
+    onFocus: (event) => {
+      if (event.currentTarget instanceof HTMLElement) {
+        getCompositeItemFocusTracker(event.currentTarget).focused = true;
+      }
+    },
+    onBlur: (event) => {
+      const currentTarget = event.currentTarget;
+      if (!(currentTarget instanceof HTMLElement)) {
+        return;
+      }
+      const tracker = getCompositeItemFocusTracker(currentTarget);
+      if (event.relatedTarget instanceof HTMLElement) {
+        tracker.focused = false;
+        return;
+      }
+
+      queueMicrotask(() => {
+        const disabledDuringBlur =
+          currentTarget instanceof HTMLElement &&
+          (currentTarget.hasAttribute('disabled') ||
+            currentTarget.getAttribute('aria-disabled') === 'true');
+
+        if (!disabledDuringBlur) {
+          tracker.focused = false;
+        }
+      });
+    },
+  };
+}
+
+export function repairFocusForDisabledItem<
+  TMetadata extends { disabled: boolean; index: number },
+>(options: {
+  collection: Collection<HTMLElement, TMetadata>;
+  disabled: boolean;
+  index: number;
+  loop: boolean;
+  node: HTMLElement | null;
+  setCurrentIndex: (index: number) => void;
+}) {
+  const { collection, disabled, index, loop, node, setCurrentIndex } = options;
+
+  if (!node) {
+    return;
+  }
+
+  const tracker = getCompositeItemFocusTracker(node);
+  const becameDisabled = disabled && !tracker.disabled;
+  tracker.disabled = disabled;
+
+  if (!becameDisabled || !tracker.focused || tracker.repairQueued) {
+    return;
+  }
+
+  tracker.repairQueued = true;
+  queueMicrotask(() => {
+    tracker.repairQueued = false;
+
+    if (!tracker.disabled || !tracker.focused) {
+      return;
+    }
+
+    const items = collection
+      .items()
+      .slice()
+      .sort((left, right) => left.metadata.index - right.metadata.index);
+    const currentPosition = items.findIndex(
+      (item) => item.metadata.index === index
+    );
+    const following = items
+      .slice(currentPosition + 1)
+      .find((item) => !item.metadata.disabled);
+    const wrapped = loop
+      ? items
+          .slice(0, Math.max(currentPosition, 0))
+          .find((item) => !item.metadata.disabled)
+      : undefined;
+    const preceding = !loop
+      ? items
+          .slice(0, Math.max(currentPosition, 0))
+          .reverse()
+          .find((item) => !item.metadata.disabled)
+      : undefined;
+    const target = following ?? wrapped ?? preceding;
+
+    tracker.focused = false;
+
+    if (!target?.node.isConnected) {
+      const activeElement = document.activeElement;
+      if (
+        activeElement instanceof HTMLElement &&
+        activeElement.hasAttribute('disabled')
+      ) {
+        activeElement.blur();
+      }
+      return;
+    }
+
+    setCurrentIndex(target.metadata.index);
+    target.node.focus();
+  });
+}

--- a/src/components/_internal/id.ts
+++ b/src/components/_internal/id.ts
@@ -1,5 +1,15 @@
+import { getSignal } from '@askrjs/askr';
 import { formatId } from '@askrjs/askr/foundations/utilities';
 import { serializeForId } from './jsx';
+
+type AutoIdLease = {
+  baseKey: string;
+  ordinal: number;
+  value: string;
+};
+
+const autoIdLeases = new WeakMap<AbortSignal, Map<string, AutoIdLease>>();
+const activeAutoIdOrdinals = new Map<string, Set<number>>();
 
 export function hashString(value: string): string {
   let hash = 2166136261;
@@ -17,10 +27,50 @@ export function resolveCompoundId(
   explicitId: string | undefined,
   identity: unknown
 ): string {
-  return formatId({
+  if (explicitId !== undefined) {
+    return formatId({ prefix, id: explicitId });
+  }
+
+  const signal = getSignal();
+  const leases = autoIdLeases.get(signal) ?? new Map<string, AutoIdLease>();
+  const existing = leases.get(prefix);
+
+  if (existing) {
+    return existing.value;
+  }
+
+  const autoId = `auto-${hashString(serializeForId(identity))}`;
+  const baseKey = `${prefix}\0${autoId}`;
+  const activeOrdinals = activeAutoIdOrdinals.get(baseKey) ?? new Set<number>();
+  let ordinal = 0;
+
+  while (activeOrdinals.has(ordinal)) {
+    ordinal += 1;
+  }
+
+  activeOrdinals.add(ordinal);
+  activeAutoIdOrdinals.set(baseKey, activeOrdinals);
+  const value = formatId({
     prefix,
-    id: explicitId ?? `auto-${hashString(serializeForId(identity))}`,
+    id: ordinal === 0 ? autoId : `${autoId}-${ordinal + 1}`,
   });
+  const lease = { baseKey, ordinal, value };
+  leases.set(prefix, lease);
+  autoIdLeases.set(signal, leases);
+  signal.addEventListener(
+    'abort',
+    () => {
+      const current = activeAutoIdOrdinals.get(baseKey);
+      current?.delete(ordinal);
+
+      if (current?.size === 0) {
+        activeAutoIdOrdinals.delete(baseKey);
+      }
+    },
+    { once: true }
+  );
+
+  return value;
 }
 
 export function resolvePartId(rootId: string, part: string): string {

--- a/src/components/_internal/menu.ts
+++ b/src/components/_internal/menu.ts
@@ -1,3 +1,4 @@
+import { getSignal, state } from '@askrjs/askr';
 import { createCollection } from '@askrjs/askr/foundations/structures';
 import { extractTextContent } from './jsx';
 
@@ -21,8 +22,63 @@ const menuCollections = new Map<
 >();
 const menuCollectionRegistrations = new Map<
   string,
-  { node: HTMLElement; owner?: object; unregister: () => void }
+  {
+    collection: ReturnType<
+      typeof createCollection<HTMLElement, MenuCollectionMetadata>
+    >;
+    metadata: MenuCollectionMetadata;
+    node: HTMLElement;
+    owner?: object;
+    unregister: () => void;
+  }
 >();
+const menuCollectionObservers = new WeakMap<
+  ReturnType<typeof createCollection<HTMLElement, MenuCollectionMetadata>>,
+  Map<
+    AbortSignal,
+    {
+      notify: () => void;
+      queued: boolean;
+      snapshot: Array<{ metadata: MenuCollectionMetadata; node: HTMLElement }>;
+    }
+  >
+>();
+
+function getMenuCollectionSnapshot(
+  collection: ReturnType<
+    typeof createCollection<HTMLElement, MenuCollectionMetadata>
+  >
+) {
+  return collection
+    .items()
+    .slice()
+    .sort((left, right) => left.metadata.index - right.metadata.index);
+}
+
+function isSameMenuCollectionSnapshot(
+  left: ReturnType<typeof getMenuCollectionSnapshot>,
+  right: ReturnType<typeof getMenuCollectionSnapshot>
+) {
+  return (
+    left.length === right.length &&
+    left.every(
+      (item, index) =>
+        item.node === right[index]?.node &&
+        isSameMenuCollectionMetadata(item.metadata, right[index]!.metadata)
+    )
+  );
+}
+
+function notifyMenuCollectionObservers(
+  collection: ReturnType<
+    typeof createCollection<HTMLElement, MenuCollectionMetadata>
+  >
+) {
+  for (const observer of menuCollectionObservers.get(collection)?.values() ??
+    []) {
+    observer.notify();
+  }
+}
 
 export function getMenuCollection(id: string) {
   const existing = menuCollections.get(id);
@@ -34,6 +90,77 @@ export function getMenuCollection(id: string) {
   const created = createCollection<HTMLElement, MenuCollectionMetadata>();
   menuCollections.set(id, created);
   return created;
+}
+
+export function observeMenuCollection(id: string) {
+  const collection = getMenuCollection(id);
+  const version = state(0);
+  version();
+  const signal = getSignal();
+  const observers = menuCollectionObservers.get(collection) ?? new Map();
+  const existing = observers.get(signal);
+
+  if (existing) {
+    existing.snapshot = getMenuCollectionSnapshot(collection);
+  }
+
+  if (!observers.has(signal)) {
+    const observer = {
+      queued: false,
+      snapshot: getMenuCollectionSnapshot(collection),
+      notify: () => {},
+    };
+    observer.notify = () => {
+      if (observer.queued) {
+        return;
+      }
+
+      observer.queued = true;
+      queueMicrotask(() => {
+        observer.queued = false;
+
+        if (signal.aborted) {
+          return;
+        }
+
+        const nextSnapshot = getMenuCollectionSnapshot(collection);
+
+        if (isSameMenuCollectionSnapshot(observer.snapshot, nextSnapshot)) {
+          return;
+        }
+
+        observer.snapshot = nextSnapshot;
+        version.set((current) => current + 1);
+      });
+    };
+    observers.set(signal, observer);
+    menuCollectionObservers.set(collection, observers);
+    signal.addEventListener(
+      'abort',
+      () => {
+        observers.delete(signal);
+
+        if (observers.size === 0) {
+          menuCollectionObservers.delete(collection);
+        }
+      },
+      { once: true }
+    );
+  }
+
+  return collection;
+}
+
+function isSameMenuCollectionMetadata(
+  left: MenuCollectionMetadata,
+  right: MenuCollectionMetadata
+) {
+  return (
+    left.index === right.index &&
+    left.disabled === right.disabled &&
+    left.value === right.value &&
+    left.text === right.text
+  );
 }
 
 export function getMenuCollectionItems(
@@ -83,13 +210,33 @@ export function registerCollectionNode(
     }
     existing?.unregister();
     menuCollectionRegistrations.delete(key);
-    return;
+    if (existing) {
+      notifyMenuCollectionObservers(existing.collection);
+    }
+    return Boolean(existing);
+  }
+
+  const metadataChanged =
+    !existing || !isSameMenuCollectionMetadata(existing.metadata, metadata);
+
+  if (
+    existing &&
+    existing.collection === collection &&
+    existing.node === node &&
+    !metadataChanged
+  ) {
+    existing.owner = owner;
+    return false;
   }
 
   existing?.unregister();
   menuCollectionRegistrations.set(key, {
+    collection,
+    metadata,
     node,
     owner,
     unregister: collection.register(node, metadata),
   });
+  notifyMenuCollectionObservers(collection);
+  return true;
 }

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -3,13 +3,17 @@ import { state } from '@askrjs/askr';
 import { Presence, Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  compositeItemFocusProps,
+  focusSelectedCollectionItem,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
 import { runCancelablePress } from '../_internal/press';
 import {
   disabledIndexes,
   firstEnabledCompositeIndex,
-  getCompositeCollection,
   getCompositeCollectionItems,
+  observeCompositeCollection,
   registerCompositeNode,
 } from '../_internal/composite';
 import {
@@ -134,7 +138,7 @@ export function Accordion(props: AccordionProps) {
       ): void;
     };
   })();
-  const collection = getCompositeCollection(accordionId);
+  const collection = observeCompositeCollection(accordionId);
   const items = getCompositeCollectionItems(collection).filter(
     (item): item is typeof item & { value: string } =>
       typeof item.value === 'string'
@@ -186,11 +190,23 @@ export function Accordion(props: AccordionProps) {
     'data-accordion': 'true',
     'data-orientation': orientation,
   });
+  const nav = rovingFocus({
+    currentIndex,
+    itemCount: Math.max(items.length, 1),
+    orientation,
+    loop,
+    isDisabled: (index) => disabledIndexList.includes(index),
+    onNavigate: (index) => {
+      currentIndexState.set(index);
+      focusSelectedCollectionItem(collection, index);
+    },
+  });
+  const mergedProps = mergeProps(finalProps, nav.container);
 
   return (
     <AccordionRootContext value={rootContext}>
       <AccordionRenderContext value={renderContext}>
-        <div {...finalProps}>{children}</div>
+        <div {...mergedProps}>{children}</div>
       </AccordionRenderContext>
     </AccordionRootContext>
   );
@@ -315,6 +331,7 @@ export function AccordionTrigger(
     isNativeButton: !asChild,
   });
   const itemFocusProps = nav.item(item.itemIndex);
+  const focusRepairProps = compositeItemFocusProps();
   const registrationOwner = {};
   const finalProps = mergeProps(rest, {
     ...interactionProps,
@@ -337,6 +354,14 @@ export function AccordionTrigger(
           },
           registrationOwner
         );
+        repairFocusForDisabledItem({
+          collection,
+          disabled: isDisabled,
+          index: item.itemIndex,
+          loop: root.loop,
+          node,
+          setCurrentIndex: root.setCurrentIndex,
+        });
       }
     ),
     id: item.triggerId,
@@ -346,6 +371,7 @@ export function AccordionTrigger(
     'data-state': open ? 'open' : 'closed',
     'data-disabled': isDisabled ? 'true' : undefined,
     tabIndex: isDisabled ? -1 : 0,
+    ...focusRepairProps,
   });
 
   if (asChild) {

--- a/src/components/dropdown/dropdown-item.tsx
+++ b/src/components/dropdown/dropdown-item.tsx
@@ -3,6 +3,10 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
 import {
+  compositeItemFocusProps,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
+import {
   getMenuCollection,
   registerCollectionNode,
   resolveMenuItemText,
@@ -79,6 +83,7 @@ export function DropdownItem(
     },
     isNativeButton: false,
   });
+  const focusRepairProps = compositeItemFocusProps();
   const handleKeyDown = (event: KeyboardEvent) => {
     if (!disabled && root.handleTypeaheadKeyDown(event)) {
       return;
@@ -108,6 +113,14 @@ export function DropdownItem(
       registrationOwner
     );
     root.restoreItemFocus(itemIndex, node);
+    repairFocusForDisabledItem({
+      collection,
+      disabled,
+      index: itemIndex,
+      loop: true,
+      node,
+      setCurrentIndex: root.setCurrentIndex,
+    });
   };
   const refHandler = ref
     ? composeRefs(
@@ -133,6 +146,7 @@ export function DropdownItem(
     'data-slot': 'dropdown-item',
     'data-disabled': disabled ? 'true' : undefined,
     'data-variant': variant && variant !== 'default' ? variant : undefined,
+    ...focusRepairProps,
   });
 
   if (asChild) {

--- a/src/components/dropdown/dropdown-root.tsx
+++ b/src/components/dropdown/dropdown-root.tsx
@@ -11,7 +11,7 @@ import {
   restorePendingCollectionItemFocus,
   type PendingCollectionFocus,
 } from '../_internal/focus';
-import { getMenuCollection } from '../_internal/menu';
+import { observeMenuCollection } from '../_internal/menu';
 import {
   handleTypeaheadKeyDown,
   handleTypeaheadKeyUp,
@@ -54,7 +54,7 @@ export function Dropdown(props: DropdownProps) {
     currentIndexCandidate: currentIndexState(),
   };
   const resolvedState = resolveDropdownState(rootContextBase);
-  const collection = getMenuCollection(dropdownId);
+  const collection = observeMenuCollection(dropdownId);
   const focusItem = (index: number) => {
     const itemValue = resolveDropdownState({
       dropdownId,

--- a/src/components/menu/menu-item.tsx
+++ b/src/components/menu/menu-item.tsx
@@ -3,6 +3,10 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import {
+  compositeItemFocusProps,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
+import {
   getMenuCollection,
   registerCollectionNode,
   resolveMenuItemText,
@@ -61,6 +65,7 @@ export function MenuItem(props: MenuItemProps | MenuItemAsChildProps) {
     interactionProps.onKeyUp?.(event);
   };
   const registrationOwner = {};
+  const focusRepairProps = compositeItemFocusProps();
   const finalProps = mergeProps(rest, {
     ...interactionProps,
     onKeyDown: handleKeyDown,
@@ -84,6 +89,14 @@ export function MenuItem(props: MenuItemProps | MenuItemAsChildProps) {
           },
           registrationOwner
         );
+        repairFocusForDisabledItem({
+          collection,
+          disabled,
+          index: itemIndex,
+          loop: root.loop,
+          node,
+          setCurrentIndex: root.setCurrentIndex,
+        });
       }
     ),
     id: itemId,
@@ -93,6 +106,7 @@ export function MenuItem(props: MenuItemProps | MenuItemAsChildProps) {
     'data-slot': 'menu-item',
     'data-disabled': disabled ? 'true' : undefined,
     tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
+    ...focusRepairProps,
   });
 
   if (asChild) {

--- a/src/components/menu/menu-root.tsx
+++ b/src/components/menu/menu-root.tsx
@@ -2,7 +2,10 @@ import { getSignal, state } from '@askrjs/askr';
 import { rovingFocus } from '@askrjs/askr/foundations/interactions';
 import { resolveCompoundId } from '../_internal/id';
 import { focusSelectedCollectionItem } from '../_internal/focus';
-import { getMenuCollection, getMenuCollectionItems } from '../_internal/menu';
+import {
+  getMenuCollectionItems,
+  observeMenuCollection,
+} from '../_internal/menu';
 import {
   handleTypeaheadKeyDown,
   handleTypeaheadKeyUp,
@@ -36,7 +39,7 @@ export function Menu(props: MenuProps) {
     currentIndexCandidate: currentIndexState(),
   };
   const resolvedState = resolveMenuState(rootContextBase);
-  const collection = getMenuCollection(menuId);
+  const collection = observeMenuCollection(menuId);
   const navigation = rovingFocus({
     currentIndex: resolvedState.currentIndex,
     itemCount: Math.max(resolvedState.items.length, 1),

--- a/src/components/menubar/menubar-content.tsx
+++ b/src/components/menubar/menubar-content.tsx
@@ -11,7 +11,10 @@ import {
   type PendingCollectionFocus,
 } from '../_internal/focus';
 import { pathIsOpen } from '../_internal/hierarchical-menu';
-import { getCompositeCollection } from '../_internal/composite';
+import {
+  getCompositeCollection,
+  observeCompositeCollection,
+} from '../_internal/composite';
 import {
   handleTypeaheadKeyDown,
   handleTypeaheadKeyUp,
@@ -74,7 +77,7 @@ function renderMenubarSurfaceContent(
       currentIndexState.set(index);
     }
   };
-  const collection = getCompositeCollection(owner.contentId);
+  const collection = observeCompositeCollection(owner.contentId);
   const focusItem = (index: number) => {
     focusCollectionItemWithRestore(pendingFocus, collection, index);
   };

--- a/src/components/menubar/menubar-item.tsx
+++ b/src/components/menubar/menubar-item.tsx
@@ -3,7 +3,11 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { state } from '@askrjs/askr';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  compositeItemFocusProps,
+  focusSelectedCollectionItem,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
 import { resolvePartId } from '../_internal/id';
 import { pathIsOpen } from '../_internal/hierarchical-menu';
 import { resolveMenuItemText } from '../_internal/menu';
@@ -95,6 +99,7 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
     isNativeButton: false,
   });
   const itemFocusProps = nav.item(surfaceIndex);
+  const focusRepairProps = compositeItemFocusProps();
   const handleKeyDown = (event: KeyboardEvent) => {
     if (!disabled && content.handleTypeaheadKeyDown(event)) {
       return;
@@ -123,6 +128,14 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
       registrationOwner
     );
     content.restoreItemFocus(surfaceIndex, node);
+    repairFocusForDisabledItem({
+      collection,
+      disabled,
+      index: surfaceIndex,
+      loop: true,
+      node,
+      setCurrentIndex: content.setCurrentIndex,
+    });
   };
   const refHandler = ref
     ? composeRefs(
@@ -147,6 +160,7 @@ export function MenubarItem(props: MenubarItemProps | MenubarItemAsChildProps) {
     'data-slot': 'menubar-item',
     'data-disabled': disabled ? 'true' : undefined,
     tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
+    ...focusRepairProps,
   });
 
   if (asChild) {
@@ -244,6 +258,7 @@ export function MenubarSubTrigger(
     },
     isNativeButton: false,
   });
+  const focusRepairProps = compositeItemFocusProps();
   const registrationOwner = {};
   const setNode = (node: HTMLElement | null) => {
     getOverlayNodes(sub.overlayIdentity).trigger = node;
@@ -259,6 +274,14 @@ export function MenubarSubTrigger(
       registrationOwner
     );
     content.restoreItemFocus(sub.surfaceIndex, node);
+    repairFocusForDisabledItem({
+      collection,
+      disabled,
+      index: sub.surfaceIndex,
+      loop: true,
+      node,
+      setCurrentIndex: content.setCurrentIndex,
+    });
   };
   const refHandler = ref
     ? composeRefs(
@@ -308,6 +331,7 @@ export function MenubarSubTrigger(
     'data-state': isOpen() ? 'open' : 'closed',
     'data-disabled': disabled ? 'true' : undefined,
     tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
+    ...focusRepairProps,
     onPointerEnter: () => {
       if (!disabled) {
         content.setCurrentIndex(sub.surfaceIndex);

--- a/src/components/menubar/menubar-menu.tsx
+++ b/src/components/menubar/menubar-menu.tsx
@@ -2,7 +2,11 @@ import { nativeButtonProps } from '../_internal/native-control';
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  compositeItemFocusProps,
+  focusSelectedCollectionItem,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
 import { resolvePartId } from '../_internal/id';
 import { pathIsOpen } from '../_internal/hierarchical-menu';
 import { resolveMenuItemText } from '../_internal/menu';
@@ -141,6 +145,7 @@ export function MenubarTrigger(
     },
     isNativeButton: false,
   });
+  const focusRepairProps = compositeItemFocusProps();
   const registrationOwner = {};
   const setNode = (node: HTMLElement | null) => {
     getOverlayNodes(menu.overlayIdentity).trigger = node;
@@ -157,6 +162,14 @@ export function MenubarTrigger(
       registrationOwner
     );
     root.restoreTriggerFocus(menu.menuIndex, node);
+    repairFocusForDisabledItem({
+      collection,
+      disabled,
+      index: menu.menuIndex,
+      loop: root.loop,
+      node,
+      setCurrentIndex: root.setCurrentTriggerIndex,
+    });
   };
   const refHandler = ref
     ? composeRefs(
@@ -206,9 +219,11 @@ export function MenubarTrigger(
     'data-disabled': disabled ? 'true' : undefined,
     'data-state': isOpen() ? 'open' : 'closed',
     tabIndex: disabled ? -1 : itemFocusProps.tabIndex,
-    onFocus: () => {
+    onFocus: (event: FocusEvent) => {
+      focusRepairProps.onFocus(event);
       root.setCurrentTriggerIndex(menu.menuIndex);
     },
+    onBlur: focusRepairProps.onBlur,
     onPointerEnter: () => {
       if (!disabled && root.getOpenPath().length > 0) {
         root.setCurrentTriggerIndex(menu.menuIndex);

--- a/src/components/menubar/menubar-root.tsx
+++ b/src/components/menubar/menubar-root.tsx
@@ -7,7 +7,7 @@ import {
   type PendingCollectionFocus,
 } from '../_internal/focus';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
-import { getCompositeCollection } from '../_internal/composite';
+import { observeCompositeCollection } from '../_internal/composite';
 import {
   handleTypeaheadKeyDown,
   handleTypeaheadKeyUp,
@@ -94,7 +94,7 @@ export function Menubar(props: MenubarProps) {
   };
   const runtimeRenderContext = createMenubarRootRenderContext();
   const rootState = resolveMenubarRootState(rootContextBase);
-  const collection = getCompositeCollection(menubarId);
+  const collection = observeCompositeCollection(menubarId);
   const syncPortals = () => {
     portalEpochState.set(portalEpochState() + 1);
   };

--- a/src/components/radio-group/radio-group-item.tsx
+++ b/src/components/radio-group/radio-group-item.tsx
@@ -2,7 +2,11 @@ import { nativeButtonProps } from '../_internal/native-control';
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  compositeItemFocusProps,
+  focusSelectedCollectionItem,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
 import {
   disabledIndexes,
   getCompositeCollection,
@@ -63,6 +67,7 @@ export function RadioGroupItem(
     isNativeButton: !asChild,
   });
   const itemFocusProps = nav.item(itemIndex);
+  const focusRepairProps = compositeItemFocusProps();
   const registrationOwner = {};
   const setNode = (node: HTMLElement | null) => {
     const changed = registerCompositeNode(
@@ -80,6 +85,14 @@ export function RadioGroupItem(
     if (changed) {
       root.scheduleItemsSync();
     }
+    repairFocusForDisabledItem({
+      collection,
+      disabled: isDisabled,
+      index: itemIndex,
+      loop: root.loop,
+      node,
+      setCurrentIndex: root.setCurrentIndex,
+    });
   };
   const refHandler = ref
     ? composeRefs(
@@ -94,6 +107,7 @@ export function RadioGroupItem(
   const finalProps = mergeProps(rest, {
     ...interactionProps,
     ...itemFocusProps,
+    ...focusRepairProps,
     ref: refHandler,
     id: itemId,
     role: 'radio',

--- a/src/components/select/select-item.tsx
+++ b/src/components/select/select-item.tsx
@@ -3,6 +3,10 @@ import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
 import {
+  compositeItemFocusProps,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
+import {
   getMenuCollection,
   registerCollectionNode,
   resolveMenuItemText,
@@ -77,6 +81,7 @@ export function SelectItem(props: SelectItemProps | SelectItemAsChildProps) {
     isNativeButton: false,
   });
   const itemFocusProps = nav.item(itemIndex);
+  const focusRepairProps = compositeItemFocusProps();
   const handleKeyDown = (event: KeyboardEvent) => {
     if (!isDisabled && root.handleTypeaheadKeyDown(event)) {
       return;
@@ -117,6 +122,14 @@ export function SelectItem(props: SelectItemProps | SelectItemAsChildProps) {
           registrationOwner
         );
         root.restoreItemFocus(itemIndex, node);
+        repairFocusForDisabledItem({
+          collection,
+          disabled: isDisabled,
+          index: itemIndex,
+          loop: true,
+          node,
+          setCurrentIndex: root.setCurrentIndex,
+        });
       }
     ),
     id: itemId,
@@ -128,6 +141,7 @@ export function SelectItem(props: SelectItemProps | SelectItemAsChildProps) {
     'data-disabled': isDisabled ? 'true' : undefined,
     'aria-disabled': isDisabled ? 'true' : undefined,
     tabIndex: isDisabled ? -1 : itemFocusProps.tabIndex,
+    ...focusRepairProps,
   });
 
   if (asChild) {

--- a/src/components/toggle-group/toggle-group-item.tsx
+++ b/src/components/toggle-group/toggle-group-item.tsx
@@ -2,7 +2,11 @@ import { nativeButtonProps } from '../_internal/native-control';
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { pressable, rovingFocus } from '@askrjs/askr/foundations/interactions';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  compositeItemFocusProps,
+  focusSelectedCollectionItem,
+  repairFocusForDisabledItem,
+} from '../_internal/focus';
 import { runCancelablePress } from '../_internal/press';
 import {
   getCompositeCollection,
@@ -80,6 +84,7 @@ export function ToggleGroupItem(
     isNativeButton: !asChild,
   });
   const itemFocusProps = nav.item(itemIndex);
+  const focusRepairProps = compositeItemFocusProps();
   const registrationOwner = {};
   const finalProps = mergeProps(rest, {
     ...interactionProps,
@@ -106,6 +111,14 @@ export function ToggleGroupItem(
         if (changed) {
           root.scheduleItemsSync();
         }
+        repairFocusForDisabledItem({
+          collection,
+          disabled: isDisabled,
+          index: itemIndex,
+          loop: root.loop,
+          node,
+          setCurrentIndex: root.setCurrentIndex,
+        });
       }
     ),
     id: itemId,
@@ -114,6 +127,7 @@ export function ToggleGroupItem(
     'data-state': pressed ? 'on' : 'off',
     'data-disabled': isDisabled ? 'true' : undefined,
     tabIndex: isDisabled ? -1 : itemFocusProps.tabIndex,
+    ...focusRepairProps,
   });
 
   if (asChild) {

--- a/tests/browser/components/accordion/behavior.test.tsx
+++ b/tests/browser/components/accordion/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import {
   Accordion,
   AccordionContent,
@@ -194,6 +195,46 @@ describe('Accordion - Behavior', () => {
     ) as HTMLElement;
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
     expect(container.textContent).not.toContain('Body');
+  });
+
+  it('should move focus when the focused trigger becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicAccordion() {
+      disabled = state(false);
+      return (
+        <Accordion orientation="vertical">
+          <AccordionItem value="one">
+            <AccordionHeader>
+              <AccordionTrigger>One</AccordionTrigger>
+            </AccordionHeader>
+          </AccordionItem>
+          <AccordionItem value="two" disabled={disabled()}>
+            <AccordionHeader>
+              <AccordionTrigger>Two</AccordionTrigger>
+            </AccordionHeader>
+          </AccordionItem>
+          <AccordionItem value="three">
+            <AccordionHeader>
+              <AccordionTrigger>Three</AccordionTrigger>
+            </AccordionHeader>
+          </AccordionItem>
+        </Accordion>
+      );
+    }
+
+    container = mount(<DynamicAccordion />);
+    await flushUpdates();
+    await flushUpdates();
+    getButtonByText(container, 'Two').focus();
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+    expect(document.activeElement).toBe(getButtonByText(container, 'Three'));
+
+    await userEvent.keyboard('{ArrowUp}');
+    await flushUpdates();
+    expect(document.activeElement).toBe(getButtonByText(container, 'One'));
   });
 
   it('should keep controlled state props off the native root', () => {

--- a/tests/browser/components/collapsible/determinism.test.tsx
+++ b/tests/browser/components/collapsible/determinism.test.tsx
@@ -5,6 +5,7 @@ import {
   CollapsibleContent,
 } from '../../../../src/components/collapsible/collapsible';
 import { createIsland } from '@askrjs/askr/boot';
+import { cleanupApp } from '@askrjs/askr/boot';
 
 function mount(element: JSX.Element): HTMLElement {
   const container = document.createElement('div');
@@ -17,6 +18,7 @@ function mount(element: JSX.Element): HTMLElement {
 }
 
 function unmount(container: HTMLElement) {
+  cleanupApp(container);
   if (container.parentNode) {
     container.parentNode.removeChild(container);
   }

--- a/tests/browser/components/cross-component/behavior.test.tsx
+++ b/tests/browser/components/cross-component/behavior.test.tsx
@@ -14,6 +14,16 @@ import {
   PopoverTrigger,
 } from '../../../../src/components/popover';
 import { VirtualList } from '../../../../src/components/virtual-list';
+import { Menu, MenuContent, MenuItem } from '../../../../src/components/menu';
+import {
+  Menubar,
+  MenubarMenu,
+  MenubarTrigger,
+} from '../../../../src/components/menubar';
+import {
+  ToggleGroup,
+  ToggleGroupItem,
+} from '../../../../src/components/toggle-group';
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
 describe('Cross-component contracts', () => {
@@ -100,5 +110,98 @@ describe('Cross-component contracts', () => {
     await flushUpdates();
     expect(container.querySelector('[data-key="a"]')).not.toBeNull();
     expect(container.querySelector('[data-key="b"]')).not.toBeNull();
+  });
+
+  it('should isolate identical composite ids while keeping each mounted identity stable', async () => {
+    let rerender!: ReturnType<typeof state<number>>;
+    function IdenticalComposites() {
+      rerender = state(0);
+      return (
+        <div data-render={rerender()}>
+          <ToggleGroup>
+            <ToggleGroupItem value="same">Same toggle</ToggleGroupItem>
+          </ToggleGroup>
+          <ToggleGroup>
+            <ToggleGroupItem value="same">Same toggle</ToggleGroupItem>
+          </ToggleGroup>
+          <Menu>
+            <MenuContent>
+              <MenuItem>Same menu item</MenuItem>
+            </MenuContent>
+          </Menu>
+          <Menu>
+            <MenuContent>
+              <MenuItem>Same menu item</MenuItem>
+            </MenuContent>
+          </Menu>
+          <Menubar>
+            <MenubarMenu value="same">
+              <MenubarTrigger>Same menubar</MenubarTrigger>
+            </MenubarMenu>
+          </Menubar>
+          <Menubar>
+            <MenubarMenu value="same">
+              <MenubarTrigger>Same menubar</MenubarTrigger>
+            </MenubarMenu>
+          </Menubar>
+          <Menu id="explicit-menu">
+            <MenuContent>
+              <MenuItem>Explicit item</MenuItem>
+            </MenuContent>
+          </Menu>
+        </div>
+      );
+    }
+
+    container = mount(<IdenticalComposites />);
+    await flushUpdates();
+    await flushUpdates();
+    const slots = ['toggle-group-item', 'menu-item', 'menubar-trigger'];
+    const initialIds = new Map<string, string[]>();
+
+    for (const slot of slots) {
+      const ids = Array.from(
+        container.querySelectorAll<HTMLElement>(`[data-slot="${slot}"]`)
+      )
+        .filter((node) => node.textContent !== 'Explicit item')
+        .map((node) => node.id);
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+      initialIds.set(slot, ids);
+    }
+    expect(
+      container.querySelector<HTMLElement>('[data-slot="menu-item"]')?.id
+    ).not.toBe('menu-explicit-menu-item-0');
+    expect(
+      Array.from(
+        container.querySelectorAll<HTMLElement>('[data-slot="menu-item"]')
+      ).find((node) => node.textContent === 'Explicit item')?.id
+    ).toBe('menu-explicit-menu-item-0');
+
+    rerender.set(1);
+    await flushUpdates();
+    await flushUpdates();
+
+    for (const slot of slots) {
+      const ids = Array.from(
+        container.querySelectorAll<HTMLElement>(`[data-slot="${slot}"]`)
+      )
+        .filter((node) => node.textContent !== 'Explicit item')
+        .map((node) => node.id);
+      expect(ids).toEqual(initialIds.get(slot));
+    }
+
+    const firstToggleId = initialIds.get('toggle-group-item')![0];
+    unmount(container);
+    container = mount(
+      <ToggleGroup>
+        <ToggleGroupItem value="same">Same toggle</ToggleGroupItem>
+      </ToggleGroup>
+    );
+    await flushUpdates();
+    expect(
+      container.querySelector<HTMLElement>('[data-slot="toggle-group-item"]')
+        ?.id
+    ).toBe(firstToggleId);
   });
 });

--- a/tests/browser/components/dropdown/behavior.test.tsx
+++ b/tests/browser/components/dropdown/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import {
   Dropdown,
   DropdownContent,
@@ -64,6 +65,35 @@ describe('Dropdown - Behavior', () => {
     await flushUpdates();
 
     expect(document.activeElement?.textContent).toBe('Archive');
+  });
+
+  it('should move focus when the focused item becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicDropdown() {
+      disabled = state(false);
+      return (
+        <Dropdown defaultOpen>
+          <DropdownTrigger>Open dropdown</DropdownTrigger>
+          <DropdownPortal>
+            <DropdownContent>
+              <DropdownItem disabled={disabled()}>Archive</DropdownItem>
+              <DropdownItem>Delete</DropdownItem>
+            </DropdownContent>
+          </DropdownPortal>
+        </Dropdown>
+      );
+    }
+
+    container = mount(<DynamicDropdown />);
+    await flushUpdates();
+    await flushUpdates();
+    expect(document.activeElement?.textContent).toBe('Archive');
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement?.textContent).toBe('Delete');
   });
 
   it('should render typed trigger and item variants for themed menus', async () => {

--- a/tests/browser/components/menu/behavior.test.tsx
+++ b/tests/browser/components/menu/behavior.test.tsx
@@ -7,7 +7,7 @@ import {
   MenuLabel,
   MenuSeparator,
 } from '../../../../src/components/menu';
-import { mount, unmount } from '../../test-utils';
+import { flushUpdates, mount, unmount } from '../../test-utils';
 
 describe('Menu - Behavior', () => {
   let container: HTMLElement;
@@ -103,5 +103,34 @@ describe('Menu - Behavior', () => {
     expect(document.activeElement).toBe(
       container.querySelector('[data-testid="after-menu"]')
     );
+  });
+
+  it('should move actual focus with vertical arrow keys', async () => {
+    container = mount(
+      <Menu loop={false}>
+        <MenuContent>
+          <MenuItem>One</MenuItem>
+          <MenuItem disabled>Two</MenuItem>
+          <MenuItem>Three</MenuItem>
+        </MenuContent>
+      </Menu>
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    const items = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    );
+    items[0]!.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await flushUpdates();
+
+    expect(document.activeElement).toBe(items[2]);
+    expect(items[2]!.getAttribute('tabindex')).toBe('0');
+    expect(items[2]!.getAttribute('data-roving-index')).toBe('2');
+
+    await userEvent.keyboard('{ArrowUp}');
+    await flushUpdates();
+    expect(document.activeElement).toBe(items[0]);
   });
 });

--- a/tests/browser/components/menu/behavior.test.tsx
+++ b/tests/browser/components/menu/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import {
   Menu,
   MenuContent,
@@ -132,5 +133,35 @@ describe('Menu - Behavior', () => {
     await userEvent.keyboard('{ArrowUp}');
     await flushUpdates();
     expect(document.activeElement).toBe(items[0]);
+  });
+
+  it('should move focus when the focused item becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicMenu() {
+      disabled = state(false);
+      return (
+        <Menu>
+          <MenuContent>
+            <MenuItem>One</MenuItem>
+            <MenuItem disabled={disabled()}>Two</MenuItem>
+            <MenuItem>Three</MenuItem>
+          </MenuContent>
+        </Menu>
+      );
+    }
+
+    container = mount(<DynamicMenu />);
+    await flushUpdates();
+    await flushUpdates();
+    const two = Array.from(
+      container.querySelectorAll<HTMLElement>('[role="menuitem"]')
+    ).find((item) => item.textContent === 'Two')!;
+    two.focus();
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement?.textContent).toBe('Three');
   });
 });

--- a/tests/browser/components/menubar/behavior.test.tsx
+++ b/tests/browser/components/menubar/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import {
   Menubar,
   MenubarContent,
@@ -151,6 +152,32 @@ describe('Menubar - Behavior', () => {
     await userEvent.keyboard('{ArrowUp}');
     await flushPortalUpdates();
     expect(document.activeElement).toBe(one);
+  });
+
+  it('should move focus when a focused root trigger becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicMenubar() {
+      disabled = state(false);
+      return (
+        <Menubar>
+          <MenubarMenu value="file">
+            <MenubarTrigger disabled={disabled()}>File</MenubarTrigger>
+          </MenubarMenu>
+          <MenubarMenu value="edit">
+            <MenubarTrigger>Edit</MenubarTrigger>
+          </MenubarMenu>
+        </Menubar>
+      );
+    }
+
+    container = mount(<DynamicMenubar />);
+    await flushPortalUpdates();
+    getButtonByText('File').focus();
+
+    disabled.set(true);
+    await flushPortalUpdates();
+
+    expect(document.activeElement).toBe(getButtonByText('Edit'));
   });
 
   it('should support typeahead, activation keys, submenus, and Tab dismissal', async () => {

--- a/tests/browser/components/menubar/behavior.test.tsx
+++ b/tests/browser/components/menubar/behavior.test.tsx
@@ -121,6 +121,38 @@ describe('Menubar - Behavior', () => {
     expect(document.body.textContent).not.toContain('New');
   });
 
+  it('should move actual focus between open menu items with vertical arrows', async () => {
+    container = mount(
+      <Menubar>
+        <MenubarMenu value="file">
+          <MenubarTrigger>File</MenubarTrigger>
+          <MenubarPortal>
+            <MenubarContent>
+              <MenubarItem>One</MenubarItem>
+              <MenubarItem disabled>Two</MenubarItem>
+              <MenubarItem>Three</MenubarItem>
+            </MenubarContent>
+          </MenubarPortal>
+        </MenubarMenu>
+      </Menubar>
+    );
+
+    getButtonByText('File').click();
+    await flushPortalUpdates();
+    const one = getButtonByText('One');
+    const three = getButtonByText('Three');
+    one.focus();
+
+    await userEvent.keyboard('{ArrowDown}');
+    await flushPortalUpdates();
+    expect(document.activeElement).toBe(three);
+    expect(three.getAttribute('tabindex')).toBe('0');
+
+    await userEvent.keyboard('{ArrowUp}');
+    await flushPortalUpdates();
+    expect(document.activeElement).toBe(one);
+  });
+
   it('should support typeahead, activation keys, submenus, and Tab dismissal', async () => {
     const onArchiveAction = vi.fn();
     container = mount(

--- a/tests/browser/components/menubar/behavior.test.tsx
+++ b/tests/browser/components/menubar/behavior.test.tsx
@@ -140,18 +140,17 @@ describe('Menubar - Behavior', () => {
 
     getButtonByText('File').click();
     await flushPortalUpdates();
-    const one = getButtonByText('One');
-    const three = getButtonByText('Three');
-    one.focus();
+    getButtonByText('One').focus();
 
     await userEvent.keyboard('{ArrowDown}');
     await flushPortalUpdates();
-    expect(document.activeElement).toBe(three);
-    expect(three.getAttribute('tabindex')).toBe('0');
+    const focusedThree = getButtonByText('Three');
+    expect(document.activeElement).toBe(focusedThree);
+    expect(focusedThree.getAttribute('tabindex')).toBe('0');
 
     await userEvent.keyboard('{ArrowUp}');
     await flushPortalUpdates();
-    expect(document.activeElement).toBe(one);
+    expect(document.activeElement).toBe(getButtonByText('One'));
   });
 
   it('should move focus when a focused root trigger becomes disabled', async () => {

--- a/tests/browser/components/radio-group/behavior.test.tsx
+++ b/tests/browser/components/radio-group/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import {
   RadioGroup,
   RadioGroupItem,
@@ -335,5 +336,78 @@ describe('RadioGroup - Behavior', () => {
     expect(
       getRadioByText(container, 'Large').getAttribute('aria-checked')
     ).toBe('false');
+  });
+
+  it('should isolate generated ids and roving focus between identical sibling groups', async () => {
+    container = mount(
+      <div>
+        <RadioGroup defaultValue="small" orientation="vertical">
+          <RadioGroupItem value="small">Small A</RadioGroupItem>
+          <RadioGroupItem value="medium">Medium A</RadioGroupItem>
+        </RadioGroup>
+        <RadioGroup defaultValue="small" orientation="vertical">
+          <RadioGroupItem value="small">Small A</RadioGroupItem>
+          <RadioGroupItem value="medium">Medium A</RadioGroupItem>
+        </RadioGroup>
+      </div>
+    );
+    await flushUpdates();
+    await flushUpdates();
+
+    const groups = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-slot="radio-group"]')
+    );
+    const firstItems = Array.from(
+      groups[0]!.querySelectorAll<HTMLElement>(
+        '[data-slot="radio-group-item"]'
+      )
+    );
+    const secondItems = Array.from(
+      groups[1]!.querySelectorAll<HTMLElement>(
+        '[data-slot="radio-group-item"]'
+      )
+    );
+
+    expect(firstItems.map((item) => item.id)).not.toEqual(
+      secondItems.map((item) => item.id)
+    );
+
+    firstItems[0]!.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    await flushUpdates();
+
+    expect(document.activeElement).toBe(firstItems[1]);
+    expect(firstItems[1]!.getAttribute('aria-checked')).toBe('true');
+    expect(secondItems[0]!.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('should repair focus when the focused item becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicRadioGroup() {
+      disabled = state(false);
+      return (
+        <RadioGroup defaultValue="medium" orientation="vertical">
+          <RadioGroupItem value="small">Small</RadioGroupItem>
+          <RadioGroupItem value="medium" disabled={disabled()}>
+            Medium
+          </RadioGroupItem>
+          <RadioGroupItem value="large">Large</RadioGroupItem>
+        </RadioGroup>
+      );
+    }
+
+    container = mount(<DynamicRadioGroup />);
+    await flushUpdates();
+    await flushUpdates();
+    getRadioByText(container, 'Medium').focus();
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement).toBe(getRadioByText(container, 'Large'));
+    expect(getRadioByText(container, 'Medium').getAttribute('tabindex')).toBe(
+      '-1'
+    );
   });
 });

--- a/tests/browser/components/radio-group/behavior.test.tsx
+++ b/tests/browser/components/radio-group/behavior.test.tsx
@@ -358,14 +358,10 @@ describe('RadioGroup - Behavior', () => {
       container.querySelectorAll<HTMLElement>('[data-slot="radio-group"]')
     );
     const firstItems = Array.from(
-      groups[0]!.querySelectorAll<HTMLElement>(
-        '[data-slot="radio-group-item"]'
-      )
+      groups[0]!.querySelectorAll<HTMLElement>('[data-slot="radio-group-item"]')
     );
     const secondItems = Array.from(
-      groups[1]!.querySelectorAll<HTMLElement>(
-        '[data-slot="radio-group-item"]'
-      )
+      groups[1]!.querySelectorAll<HTMLElement>('[data-slot="radio-group-item"]')
     );
 
     expect(firstItems.map((item) => item.id)).not.toEqual(
@@ -409,5 +405,34 @@ describe('RadioGroup - Behavior', () => {
     expect(getRadioByText(container, 'Medium').getAttribute('tabindex')).toBe(
       '-1'
     );
+  });
+
+  it('should leave no disabled item focused when every item becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function AllDisabledRadioGroup() {
+      disabled = state(false);
+      return (
+        <RadioGroup defaultValue="only">
+          <RadioGroupItem value="only" disabled={disabled()}>
+            Only
+          </RadioGroupItem>
+        </RadioGroup>
+      );
+    }
+
+    container = mount(<AllDisabledRadioGroup />);
+    await flushUpdates();
+    const only = getRadioByText(container, 'Only');
+    only.focus();
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement).not.toBe(only);
+    expect(
+      document.activeElement instanceof HTMLElement &&
+        document.activeElement.hasAttribute('disabled')
+    ).toBe(false);
   });
 });

--- a/tests/browser/components/select/behavior.test.tsx
+++ b/tests/browser/components/select/behavior.test.tsx
@@ -1,5 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { state } from '@askrjs/askr';
 import {
   Select,
   SelectContent,
@@ -105,6 +106,39 @@ describe('Select - Behavior', () => {
     await flushUpdates();
 
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('should move focus when the focused option becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicSelect() {
+      disabled = state(false);
+      return (
+        <Select defaultOpen defaultValue="askr">
+          <SelectTrigger>
+            <SelectValue placeholder="Choose one" />
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectContent>
+              <SelectItem value="askr" disabled={disabled()}>
+                Askr
+              </SelectItem>
+              <SelectItem value="solid">Solid</SelectItem>
+            </SelectContent>
+          </SelectPortal>
+        </Select>
+      );
+    }
+
+    container = mount(<DynamicSelect />);
+    await flushUpdates();
+    await flushUpdates();
+    expect(document.activeElement?.textContent).toBe('Askr');
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement?.textContent).toBe('Solid');
   });
 
   it('should use explicit item text values for trigger rendering', () => {

--- a/tests/browser/components/toggle-group/behavior.test.tsx
+++ b/tests/browser/components/toggle-group/behavior.test.tsx
@@ -1,6 +1,6 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
-import { For } from '@askrjs/askr';
+import { For, state } from '@askrjs/askr';
 import {
   ToggleGroup,
   ToggleGroupItem,
@@ -471,5 +471,32 @@ describe('ToggleGroup - Behavior', () => {
     expect(
       getToggleByText(container, 'Middle').getAttribute('aria-pressed')
     ).toBe('false');
+  });
+
+  it('should move focus when the focused item becomes disabled', async () => {
+    let disabled!: ReturnType<typeof state<boolean>>;
+    function DynamicToggleGroup() {
+      disabled = state(false);
+      return (
+        <ToggleGroup defaultValue="middle" orientation="vertical">
+          <ToggleGroupItem value="left">Left</ToggleGroupItem>
+          <ToggleGroupItem value="middle" disabled={disabled()}>
+            Middle
+          </ToggleGroupItem>
+          <ToggleGroupItem value="right">Right</ToggleGroupItem>
+        </ToggleGroup>
+      );
+    }
+
+    container = mount(<DynamicToggleGroup />);
+    await flushUpdates();
+    await flushUpdates();
+    getToggleByText(container, 'Middle').focus();
+
+    disabled.set(true);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(document.activeElement).toBe(getToggleByText(container, 'Right'));
   });
 });

--- a/tests/unit/composite-id.test.tsx
+++ b/tests/unit/composite-id.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { renderToStringSync } from '@askrjs/askr/ssr';
+import { RadioGroup, RadioGroupItem } from '../../src/components/radio-group';
+
+function IdenticalServerComposites() {
+  return (
+    <div>
+      <RadioGroup defaultValue="same">
+        <RadioGroupItem value="same">Same</RadioGroupItem>
+      </RadioGroup>
+      <RadioGroup defaultValue="same">
+        <RadioGroupItem value="same">Same</RadioGroupItem>
+      </RadioGroup>
+    </div>
+  );
+}
+
+describe('Composite generated identity', () => {
+  it('should render identical SSR siblings with unique and repeatable ids', () => {
+    const first = renderToStringSync(IdenticalServerComposites);
+    const second = renderToStringSync(IdenticalServerComposites);
+    const ids = Array.from(
+      first.matchAll(/\sid="([^"]+)"/g),
+      (match) => match[1]
+    );
+
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+    expect(second).toBe(first);
+  });
+});

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -56,4 +56,69 @@ describe('Source layout', () => {
     );
     expect(sharedControl).toContain("font: 'inherit'");
   });
+
+  it('should keep roving composites on the shared identity and focus guardrails', () => {
+    const componentsDirectory = join(process.cwd(), 'src', 'components');
+    const missingFocusRepair: string[] = [];
+
+    for (const directory of readComponentDirectories()) {
+      if (directory === '_internal') continue;
+      const componentDirectory = join(componentsDirectory, directory);
+      for (const entry of readdirSync(componentDirectory, {
+        withFileTypes: true,
+      })) {
+        if (!entry.isFile() || !entry.name.endsWith('.tsx')) continue;
+        const path = join(componentDirectory, entry.name);
+        const source = readFileSync(path, 'utf8');
+        const ownsRovingItems =
+          source.includes('rovingFocus({') &&
+          source.includes('const interactionProps = pressable');
+
+        if (ownsRovingItems && !source.includes('repairFocusForDisabledItem')) {
+          missingFocusRepair.push(`${directory}/${entry.name}`);
+        }
+      }
+    }
+
+    const menuItem = readFileSync(
+      join(componentsDirectory, 'menu', 'menu-item.tsx'),
+      'utf8'
+    );
+    expect(menuItem).toContain('repairFocusForDisabledItem');
+    expect(missingFocusRepair).toEqual([]);
+
+    const behaviorSuites = [
+      'accordion',
+      'dropdown',
+      'menu',
+      'menubar',
+      'radio-group',
+      'select',
+      'toggle-group',
+    ];
+    for (const suite of behaviorSuites) {
+      const source = readFileSync(
+        join(
+          process.cwd(),
+          'tests',
+          'browser',
+          'components',
+          suite,
+          'behavior.test.tsx'
+        ),
+        'utf8'
+      );
+      expect(source).toContain('document.activeElement');
+      expect(source).toMatch(/Arrow(?:Down|Up|Left|Right)/);
+      expect(source).toContain('becomes disabled');
+    }
+
+    const identitySource = readFileSync(
+      join(componentsDirectory, '_internal', 'id.ts'),
+      'utf8'
+    );
+    expect(identitySource).toContain('activeAutoIdOrdinals');
+    expect(identitySource).toContain("addEventListener(\n    'abort'");
+    expect(identitySource).not.toMatch(/Math\.random|randomUUID/);
+  });
 });

--- a/vitest.test.unit.config.ts
+++ b/vitest.test.unit.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     include: [
       'tests/unit/bench-contract.test.ts',
       'tests/unit/browser-bench-contract.test.ts',
+      'tests/unit/composite-id.test.tsx',
       'tests/unit/foundations-contract.test.ts',
       'tests/unit/source-layout.test.ts',
       'tests/unit/public-api.test.ts',


### PR DESCRIPTION
## Summary

- allocate lifecycle-scoped generated IDs so identical mounted composites never share DOM or registry identity
- make menu/composite collections notify roots after registration changes without render-time state mutation or ref-churn loops
- repair focus through one DOM-node WeakMap contract when a focused item becomes disabled
- restore real ArrowUp/ArrowDown navigation for Menu, Menubar content, and Accordion
- cover every public roving primitive plus deterministic browser and SSR identity paths

## Linked issues

Closes #50
Closes #54
Closes #58

## TDD

- Red `b10290a`: all three engines reproduced duplicate RadioGroup IDs/collection interference, Chromium focus loss and Firefox/WebKit focus stickiness after disablement, and inert Menu/Menubar arrow navigation.
- Green `1871a7c`: lifecycle ID leases, post-commit collection observation, and node-owned focus repair make the same cases green without component hook overhead.

## Guardrails

- identical sibling RadioGroup, ToggleGroup, Menu, and Menubar instances assert distinct IDs and rerender stability
- SSR renders identical siblings with unique IDs and repeats byte-for-byte; explicit IDs remain unchanged
- lifecycle abort releases generated-ID ordinals and cleanup/remount reuses deterministic markup
- Accordion, Dropdown, Menu, Menubar, RadioGroup, Select, and ToggleGroup all cover focused-item disablement in Chromium, Firefox, and WebKit
- all-disabled, disabled-item skipping, loop/non-loop, active-element, tabindex, and roving-index boundaries are asserted
- source contract rejects public roving item implementations that bypass shared focus repair or lack baseline arrow/disable tests
- collection observers compare post-commit snapshots, avoiding render-time mutation and ref teardown/re-registration loops

## Acceptance audit

- [x] Every behavioral, compatibility, and guardrail criterion in #50, #54, and #58 is implemented locally.
- [x] Red and green states are recorded separately.
- [x] Full local release gate, all four benchmark tiers, packed-artifact validation, and production dependency audit pass.
- [x] Every linked issue checkbox is checked with exact-head hosted CI evidence before merge.
- [x] Exact squash merge, tag, publish workflow, and clean registry consumer are verified.

## Verification

- `npm run check` — 309 browser files / 1,248 browser tests across Chromium, Firefox, and WebKit, plus unit, checks, jsdom, type, build, publint, and 1,204-file packed-artifact validation
- `npm run bench` — all four benchmark tiers
- `npm audit --omit=dev` — 0 vulnerabilities
