### PR TITLE
fix: stabilize async interaction lifecycles (#55, #56, #57)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/hover-card/hover-card.tsx
+++ b/src/components/hover-card/hover-card.tsx
@@ -46,6 +46,11 @@ export function HoverCard(props: HoverCardProps) {
     restoreFrame: null as number | null,
     restoreGeneration: 0,
   })();
+  const pointerEntry = state({
+    document: null as Document | null,
+    handler: null as ((event: PointerEvent) => void) | null,
+    sync: null as ((event: PointerEvent) => void) | null,
+  })();
   captureOverlayNonce(overlayIdentity, cspNonce());
   const triggerId = resolvePartId(hoverCardId, 'trigger');
   const contentId = resolvePartId(hoverCardId, 'content');
@@ -193,6 +198,46 @@ export function HoverCard(props: HoverCardProps) {
     },
   };
   const PortalHost = portal;
+
+  pointerEntry.sync = (event: PointerEvent) => {
+    const target = event.target;
+    const isInside =
+      target instanceof Node &&
+      (overlayNodes.trigger?.contains(target) === true ||
+        overlayNodes.content?.contains(target) === true);
+    if (isInside) {
+      clearCloseTimer();
+      return;
+    }
+
+    clearOpenTimer();
+    if (openState() && closeTimer === undefined) {
+      rootContext.scheduleClose();
+    }
+  };
+
+  if (!pointerEntry.handler) {
+    pointerEntry.document = document;
+    pointerEntry.handler = (event: PointerEvent) => {
+      pointerEntry.sync?.(event);
+    };
+    pointerEntry.document.addEventListener('pointerover', pointerEntry.handler);
+    cleanupSignal.addEventListener(
+      'abort',
+      () => {
+        if (pointerEntry.document && pointerEntry.handler) {
+          pointerEntry.document.removeEventListener(
+            'pointerover',
+            pointerEntry.handler
+          );
+        }
+        pointerEntry.document = null;
+        pointerEntry.handler = null;
+        pointerEntry.sync = null;
+      },
+      { once: true }
+    );
+  }
 
   return (
     <HoverCardRootContext value={rootContext}>

--- a/src/components/hover-card/hover-card.tsx
+++ b/src/components/hover-card/hover-card.tsx
@@ -79,16 +79,21 @@ export function HoverCard(props: HoverCardProps) {
   let openTimer: ReturnType<typeof setTimeout> | undefined;
   let closeTimer: ReturnType<typeof setTimeout> | undefined;
 
-  const clearTimers = () => {
-    if (openTimer) {
+  const clearOpenTimer = () => {
+    if (openTimer !== undefined) {
       clearTimeout(openTimer);
       openTimer = undefined;
     }
-
-    if (closeTimer) {
+  };
+  const clearCloseTimer = () => {
+    if (closeTimer !== undefined) {
       clearTimeout(closeTimer);
       closeTimer = undefined;
     }
+  };
+  const clearTimers = () => {
+    clearOpenTimer();
+    clearCloseTimer();
   };
   const cleanupSignal = getSignal();
   cleanupSignal.addEventListener(
@@ -127,28 +132,28 @@ export function HoverCard(props: HoverCardProps) {
       });
     },
     scheduleOpen: () => {
-      if (openTimer) {
-        clearTimeout(openTimer);
-      }
+      clearCloseTimer();
+      clearOpenTimer();
 
       if (openState()) {
         return;
       }
 
       openTimer = setTimeout(() => {
+        openTimer = undefined;
         rootContext.setOpen(true);
       }, openDelay);
     },
     scheduleClose: () => {
-      if (closeTimer) {
-        clearTimeout(closeTimer);
-      }
+      clearOpenTimer();
+      clearCloseTimer();
 
       closeTimer = setTimeout(() => {
+        closeTimer = undefined;
         rootContext.setOpen(false);
       }, closeDelay);
     },
-    cancelClose: clearTimers,
+    cancelClose: clearCloseTimer,
     triggerId,
     contentId,
     portal,

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -24,7 +24,7 @@ import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
 import { controllableState } from '@askrjs/askr/foundations/state';
 import { pressable } from '@askrjs/askr/foundations/interactions';
 import { runCancelablePress } from '../_internal/press';
-import { state } from '@askrjs/askr';
+import { For, state } from '@askrjs/askr';
 import { resource } from '@askrjs/askr/resources';
 import { DismissableLayer } from '../dismissable-layer';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
@@ -371,16 +371,17 @@ export function ToastViewport(
 ) {
   const { asChild, children, ref, ...rest } = props;
   const host = readToastHostContext();
-  const toastRegistrations = host.getToasts();
   const content = (
     <>
-      {toastRegistrations.map((registration) => (
-        <ToastRegistrationView
-          key={registration.toastId}
-          registration={registration}
-          host={host}
-        />
-      ))}
+      <For each={host.getToasts} by={(registration) => registration.toastId}>
+        {(registration) => (
+          <ToastRegistrationView
+            key={registration.toastId}
+            registration={registration}
+            host={host}
+          />
+        )}
+      </For>
       {children}
     </>
   );

--- a/src/components/tooltip/tooltip-root.tsx
+++ b/src/components/tooltip/tooltip-root.tsx
@@ -1,5 +1,5 @@
 import { controllableState } from '@askrjs/askr/foundations/state';
-import { cspNonce, state } from '@askrjs/askr';
+import { cspNonce, getSignal, state } from '@askrjs/askr';
 import { resolveCompoundId, resolvePartId } from '../_internal/id';
 import {
   captureOverlayNonce,
@@ -33,30 +33,82 @@ export function Tooltip(props: TooltipProps) {
   });
   const tooltipId = resolveCompoundId('tooltip', id, children);
   const overlayIdentity = state(createOverlayIdentity())();
+  const focusEntry = state({
+    adoptTrigger: false,
+    generation: 0,
+    releaseFrame: null as number | null,
+  })();
   captureOverlayNonce(overlayIdentity, cspNonce());
   const contentId = resolvePartId(tooltipId, 'content');
   const portal = getPersistentPortal(overlayIdentity);
   const overlayNodes = getOverlayNodes(overlayIdentity);
   let contentPosition: TooltipPositionOptions = resolveTooltipPositionOptions();
+  const cleanupSignal = getSignal();
+
+  const releaseTriggerAdoption = () => {
+    const generation = focusEntry.generation + 1;
+    focusEntry.generation = generation;
+    if (focusEntry.releaseFrame !== null) {
+      cancelAnimationFrame(focusEntry.releaseFrame);
+    }
+    queueMicrotask(() => {
+      if (cleanupSignal.aborted) {
+        focusEntry.adoptTrigger = false;
+        return;
+      }
+      focusEntry.releaseFrame = requestAnimationFrame(() => {
+        focusEntry.releaseFrame = null;
+        if (focusEntry.generation === generation) {
+          focusEntry.adoptTrigger = false;
+        }
+      });
+    });
+  };
+
+  cleanupSignal.addEventListener(
+    'abort',
+    () => {
+      if (focusEntry.releaseFrame !== null) {
+        cancelAnimationFrame(focusEntry.releaseFrame);
+        focusEntry.releaseFrame = null;
+      }
+      focusEntry.adoptTrigger = false;
+      focusEntry.generation += 1;
+    },
+    { once: true }
+  );
+
+  const updateOpen = (nextOpen: boolean) => {
+    if (!nextOpen && focusEntry.adoptTrigger) {
+      return;
+    }
+    if (openState() === nextOpen) {
+      return;
+    }
+    openState.set(nextOpen);
+
+    if (!nextOpen) {
+      clearOverlayPosition(overlayIdentity);
+      return;
+    }
+
+    scheduleTooltipPortalSync(() => {
+      if (overlayNodes.content) {
+        syncOverlayPosition(overlayIdentity, tooltipId, contentPosition);
+      }
+    });
+  };
 
   const rootContext: TooltipRootContextValue = {
     tooltipId,
     get open() {
       return openState();
     },
-    setOpen: (nextOpen: boolean) => {
-      openState.set(nextOpen);
-
-      if (!nextOpen) {
-        clearOverlayPosition(overlayIdentity);
-        return;
-      }
-
-      scheduleTooltipPortalSync(() => {
-        if (overlayNodes.content) {
-          syncOverlayPosition(overlayIdentity, tooltipId, contentPosition);
-        }
-      });
+    setOpen: updateOpen,
+    openFromFocus: () => {
+      focusEntry.adoptTrigger = true;
+      updateOpen(true);
+      releaseTriggerAdoption();
     },
     contentId,
     portal,
@@ -65,6 +117,9 @@ export function Tooltip(props: TooltipProps) {
     },
     setTriggerNode: (node: HTMLElement | null) => {
       overlayNodes.trigger = node;
+      if (node && focusEntry.adoptTrigger && document.activeElement !== node) {
+        node.focus();
+      }
     },
     setContentNode: (node: HTMLElement | null) => {
       overlayNodes.content = node;

--- a/src/components/tooltip/tooltip-trigger.tsx
+++ b/src/components/tooltip/tooltip-trigger.tsx
@@ -53,7 +53,7 @@ export function TooltipTrigger(
     ...hoverProps,
     ref: refHandler,
     onFocus: () => {
-      root.setOpen(true);
+      root.openFromFocus();
     },
     onBlur: () => {
       root.setOpen(false);

--- a/src/components/tooltip/tooltip.shared.ts
+++ b/src/components/tooltip/tooltip.shared.ts
@@ -15,6 +15,7 @@ export type TooltipRootContextValue = {
   tooltipId: string;
   open: boolean;
   setOpen: (open: boolean) => void;
+  openFromFocus: () => void;
   contentId: string;
   portal: OverlayPortal;
   registerContentPosition: (position: TooltipPositionOptions) => void;

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -1,10 +1,17 @@
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import { flush as flushScheduler } from '@askrjs/askr/testing';
 import {
   HoverCard,
   HoverCardContent,
   HoverCardTrigger,
 } from '../../../../src/components/hover-card';
 import { flushUpdates, mount, unmount } from '../../test-utils';
+
+async function advanceHoverCardTimers(milliseconds: number): Promise<void> {
+  await vi.advanceTimersByTimeAsync(milliseconds);
+  flushScheduler();
+  await flushUpdates();
+}
 
 async function waitForHoverCardState(
   container: HTMLElement,
@@ -50,8 +57,7 @@ describe('HoverCard - Behavior', () => {
 
     trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
     await flushUpdates();
-    await vi.advanceTimersByTimeAsync(1);
-    await flushUpdates();
+    await advanceHoverCardTimers(1);
 
     const openTrigger = await waitForHoverCardState(container, 'open');
 
@@ -64,7 +70,7 @@ describe('HoverCard - Behavior', () => {
       new PointerEvent('pointerleave', { bubbles: true })
     );
     await flushUpdates();
-    await vi.advanceTimersByTimeAsync(90);
+    await advanceHoverCardTimers(90);
     const closedTrigger = await waitForHoverCardState(container, 'closed');
 
     expect(closedTrigger.getAttribute('data-state')).toBe('closed');
@@ -137,8 +143,7 @@ describe('HoverCard - Behavior', () => {
     ) as HTMLElement;
     trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
     content.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
-    await vi.advanceTimersByTimeAsync(60);
-    await flushUpdates();
+    await advanceHoverCardTimers(60);
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
     ).not.toBeNull();
@@ -160,8 +165,7 @@ describe('HoverCard - Behavior', () => {
     trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
     trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
 
-    await vi.advanceTimersByTimeAsync(100);
-    await flushUpdates();
+    await advanceHoverCardTimers(100);
 
     const currentTrigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
@@ -187,10 +191,9 @@ describe('HoverCard - Behavior', () => {
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
     trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
-    await vi.advanceTimersByTimeAsync(40);
+    await advanceHoverCardTimers(40);
     trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
-    await vi.advanceTimersByTimeAsync(60);
-    await flushUpdates();
+    await advanceHoverCardTimers(60);
 
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
@@ -213,16 +216,15 @@ describe('HoverCard - Behavior', () => {
       trigger.dispatchEvent(
         new PointerEvent('pointerenter', { bubbles: true })
       );
-      await vi.advanceTimersByTimeAsync(10);
+      await advanceHoverCardTimers(10);
       trigger.dispatchEvent(
         new PointerEvent('pointerleave', { bubbles: true })
       );
-      await vi.advanceTimersByTimeAsync(10);
+      await advanceHoverCardTimers(10);
     }
     trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
 
-    await vi.advanceTimersByTimeAsync(100);
-    await flushUpdates();
+    await advanceHoverCardTimers(100);
 
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
@@ -246,7 +248,7 @@ describe('HoverCard - Behavior', () => {
     unmount(container);
     container = undefined;
 
-    await vi.advanceTimersByTimeAsync(100);
+    await advanceHoverCardTimers(100);
     expect(onOpenChange).not.toHaveBeenCalled();
   });
 

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -6,6 +6,23 @@ import {
 } from '../../../../src/components/hover-card';
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
+async function waitForHoverCardState(
+  container: HTMLElement,
+  expected: 'open' | 'closed'
+): Promise<HTMLElement> {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement | null;
+    if (trigger?.getAttribute('data-state') === expected) {
+      return trigger;
+    }
+    await flushUpdates();
+  }
+
+  throw new Error(`Expected HoverCard trigger to become ${expected}`);
+}
+
 describe('HoverCard - Behavior', () => {
   let container: HTMLElement | undefined;
 
@@ -18,9 +35,10 @@ describe('HoverCard - Behavior', () => {
 
   it('should open and close from hover and focus state changes', async () => {
     vi.useFakeTimers();
+    const onOpenChange = vi.fn();
 
     container = mount(
-      <HoverCard>
+      <HoverCard onOpenChange={onOpenChange}>
         <HoverCardTrigger>Preview</HoverCardTrigger>
         <HoverCardContent>Details</HoverCardContent>
       </HoverCard>
@@ -34,9 +52,7 @@ describe('HoverCard - Behavior', () => {
     await vi.advanceTimersByTimeAsync(1);
     await flushUpdates();
 
-    const openTrigger = container.querySelector(
-      '[data-slot="hover-card-trigger"]'
-    ) as HTMLElement;
+    const openTrigger = await waitForHoverCardState(container, 'open');
 
     expect(openTrigger.getAttribute('data-state')).toBe('open');
     expect(
@@ -47,16 +63,13 @@ describe('HoverCard - Behavior', () => {
       new PointerEvent('pointerleave', { bubbles: true })
     );
     await vi.runAllTimersAsync();
-    await flushUpdates();
-
-    const closedTrigger = container.querySelector(
-      '[data-slot="hover-card-trigger"]'
-    ) as HTMLElement;
+    const closedTrigger = await waitForHoverCardState(container, 'closed');
 
     expect(closedTrigger.getAttribute('data-state')).toBe('closed');
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
     ).toBeNull();
+    expect(onOpenChange.mock.calls).toEqual([[true], [false]]);
   });
 
   it('should support asChild composition and ref forwarding', async () => {

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { flush as flushScheduler } from '@askrjs/askr/testing';
 import {
@@ -36,6 +37,25 @@ async function waitForHoverCardState(
   throw new Error(`Expected HoverCard trigger to become ${expected}`);
 }
 
+function getPointerExitTarget(): HTMLElement {
+  const existing = document.querySelector(
+    '[data-hover-card-pointer-exit]'
+  ) as HTMLElement | null;
+  if (existing) {
+    return existing;
+  }
+  const target = document.createElement('button');
+  target.setAttribute('data-hover-card-pointer-exit', 'true');
+  target.style.position = 'fixed';
+  target.style.right = '0';
+  target.style.bottom = '0';
+  target.style.width = '2px';
+  target.style.height = '2px';
+  target.style.zIndex = '2147483647';
+  document.body.appendChild(target);
+  return target;
+}
+
 describe('HoverCard - Behavior', () => {
   let container: HTMLElement | undefined;
 
@@ -43,6 +63,7 @@ describe('HoverCard - Behavior', () => {
     vi.useRealTimers();
     vi.restoreAllMocks();
     unmount(container);
+    document.querySelector('[data-hover-card-pointer-exit]')?.remove();
     container = undefined;
   });
 
@@ -61,7 +82,7 @@ describe('HoverCard - Behavior', () => {
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
 
-    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await userEvent.hover(trigger);
     await flushUpdates();
     await advanceHoverCardTimers(1);
 
@@ -72,9 +93,7 @@ describe('HoverCard - Behavior', () => {
       document.body.querySelector('[data-slot="hover-card-content"]')
     ).not.toBeNull();
 
-    openTrigger.dispatchEvent(
-      new PointerEvent('pointerleave', { bubbles: true })
-    );
+    await userEvent.hover(getPointerExitTarget());
     await flushUpdates();
     await advanceHoverCardTimers(90);
     const closedTrigger = await waitForHoverCardState(container, 'closed');
@@ -147,8 +166,7 @@ describe('HoverCard - Behavior', () => {
     const content = document.body.querySelector(
       '[data-slot="hover-card-content"]'
     ) as HTMLElement;
-    trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
-    content.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await userEvent.hover(content);
     await advanceHoverCardTimers(60);
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
@@ -168,8 +186,8 @@ describe('HoverCard - Behavior', () => {
     const trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
-    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
-    trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+    await userEvent.hover(trigger);
+    await userEvent.hover(getPointerExitTarget());
 
     await advanceHoverCardTimers(100);
 
@@ -196,9 +214,9 @@ describe('HoverCard - Behavior', () => {
     const trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
-    trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+    await userEvent.hover(getPointerExitTarget());
     await advanceHoverCardTimers(40);
-    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await userEvent.hover(trigger);
     await advanceHoverCardTimers(60);
 
     expect(
@@ -219,16 +237,12 @@ describe('HoverCard - Behavior', () => {
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
     for (let cycle = 0; cycle < 5; cycle += 1) {
-      trigger.dispatchEvent(
-        new PointerEvent('pointerenter', { bubbles: true })
-      );
+      await userEvent.hover(trigger);
       await advanceHoverCardTimers(10);
-      trigger.dispatchEvent(
-        new PointerEvent('pointerleave', { bubbles: true })
-      );
+      await userEvent.hover(getPointerExitTarget());
       await advanceHoverCardTimers(10);
     }
-    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await userEvent.hover(trigger);
 
     await advanceHoverCardTimers(100);
 
@@ -250,7 +264,7 @@ describe('HoverCard - Behavior', () => {
     const trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
-    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await userEvent.hover(trigger);
     unmount(container);
     container = undefined;
 

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -144,8 +144,9 @@ describe('HoverCard - Behavior', () => {
 
   it('should cancel a pending open when the pointer leaves immediately', async () => {
     vi.useFakeTimers();
+    const onOpenChange = vi.fn();
     container = mount(
-      <HoverCard openDelay={0} closeDelay={90}>
+      <HoverCard openDelay={0} closeDelay={90} onOpenChange={onOpenChange}>
         <HoverCardTrigger>Preview</HoverCardTrigger>
         <HoverCardContent>Details</HoverCardContent>
       </HoverCard>
@@ -160,10 +161,14 @@ describe('HoverCard - Behavior', () => {
     await vi.advanceTimersByTimeAsync(100);
     await flushUpdates();
 
-    expect(trigger.getAttribute('data-state')).toBe('closed');
+    const currentTrigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    expect(currentTrigger.getAttribute('data-state')).toBe('closed');
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
     ).toBeNull();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it('should cancel a pending close when the pointer re-enters before its deadline', async () => {

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -8,9 +8,13 @@ import {
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
 async function advanceHoverCardTimers(milliseconds: number): Promise<void> {
+  flushScheduler();
+  await flushUpdates();
+  flushScheduler();
   await vi.advanceTimersByTimeAsync(milliseconds);
   flushScheduler();
   await flushUpdates();
+  flushScheduler();
 }
 
 async function waitForHoverCardState(
@@ -18,13 +22,15 @@ async function waitForHoverCardState(
   expected: 'open' | 'closed'
 ): Promise<HTMLElement> {
   for (let attempt = 0; attempt < 20; attempt += 1) {
+    flushScheduler();
+    await flushUpdates();
+    flushScheduler();
     const trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement | null;
     if (trigger?.getAttribute('data-state') === expected) {
       return trigger;
     }
-    await flushUpdates();
   }
 
   throw new Error(`Expected HoverCard trigger to become ${expected}`);

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -177,6 +177,59 @@ describe('HoverCard - Behavior', () => {
     ).not.toBeNull();
   });
 
+  it('should honor the final pointer state through repeated timer churn', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <HoverCard openDelay={20} closeDelay={90}>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    for (let cycle = 0; cycle < 5; cycle += 1) {
+      trigger.dispatchEvent(
+        new PointerEvent('pointerenter', { bubbles: true })
+      );
+      await vi.advanceTimersByTimeAsync(10);
+      trigger.dispatchEvent(
+        new PointerEvent('pointerleave', { bubbles: true })
+      );
+      await vi.advanceTimersByTimeAsync(10);
+    }
+    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(100);
+    await flushUpdates();
+
+    expect(
+      document.body.querySelector('[data-slot="hover-card-content"]')
+    ).not.toBeNull();
+  });
+
+  it('should cancel both transition timers during teardown', async () => {
+    vi.useFakeTimers();
+    const onOpenChange = vi.fn();
+    container = mount(
+      <HoverCard openDelay={50} closeDelay={50} onOpenChange={onOpenChange}>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    unmount(container);
+    container = undefined;
+
+    await vi.advanceTimersByTimeAsync(100);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   it('should expose complete dialog labeling given a trigger and content when the card is open', async () => {
     container = mount(
       <HoverCard defaultOpen>

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -49,6 +49,7 @@ describe('HoverCard - Behavior', () => {
     ) as HTMLElement;
 
     trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await flushUpdates();
     await vi.advanceTimersByTimeAsync(1);
     await flushUpdates();
 
@@ -62,7 +63,8 @@ describe('HoverCard - Behavior', () => {
     openTrigger.dispatchEvent(
       new PointerEvent('pointerleave', { bubbles: true })
     );
-    await vi.runAllTimersAsync();
+    await flushUpdates();
+    await vi.advanceTimersByTimeAsync(90);
     const closedTrigger = await waitForHoverCardState(container, 'closed');
 
     expect(closedTrigger.getAttribute('data-state')).toBe('closed');

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -226,8 +226,9 @@ describe('HoverCard - Behavior', () => {
 
   it('should honor the final pointer state through repeated timer churn', async () => {
     vi.useFakeTimers();
+    const onOpenChange = vi.fn();
     container = mount(
-      <HoverCard openDelay={20} closeDelay={90}>
+      <HoverCard openDelay={20} closeDelay={90} onOpenChange={onOpenChange}>
         <HoverCardTrigger>Preview</HoverCardTrigger>
         <HoverCardContent>Details</HoverCardContent>
       </HoverCard>
@@ -236,7 +237,7 @@ describe('HoverCard - Behavior', () => {
     const trigger = container.querySelector(
       '[data-slot="hover-card-trigger"]'
     ) as HTMLElement;
-    for (let cycle = 0; cycle < 5; cycle += 1) {
+    for (let cycle = 0; cycle < 3; cycle += 1) {
       await userEvent.hover(trigger);
       await advanceHoverCardTimers(10);
       await userEvent.hover(getPointerExitTarget());
@@ -249,6 +250,7 @@ describe('HoverCard - Behavior', () => {
     expect(
       document.body.querySelector('[data-slot="hover-card-content"]')
     ).not.toBeNull();
+    expect(onOpenChange.mock.calls).toEqual([[true]]);
   });
 
   it('should cancel both transition timers during teardown', async () => {

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -129,6 +129,54 @@ describe('HoverCard - Behavior', () => {
     ).not.toBeNull();
   });
 
+  it('should cancel a pending open when the pointer leaves immediately', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <HoverCard openDelay={0} closeDelay={90}>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+
+    await vi.advanceTimersByTimeAsync(100);
+    await flushUpdates();
+
+    expect(trigger.getAttribute('data-state')).toBe('closed');
+    expect(
+      document.body.querySelector('[data-slot="hover-card-content"]')
+    ).toBeNull();
+  });
+
+  it('should cancel a pending close when the pointer re-enters before its deadline', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <HoverCard defaultOpen closeDelay={90}>
+        <HoverCardTrigger>Preview</HoverCardTrigger>
+        <HoverCardContent>Details</HoverCardContent>
+      </HoverCard>
+    );
+    await flushUpdates();
+
+    const trigger = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLElement;
+    trigger.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(40);
+    trigger.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true }));
+    await vi.advanceTimersByTimeAsync(60);
+    await flushUpdates();
+
+    expect(
+      document.body.querySelector('[data-slot="hover-card-content"]')
+    ).not.toBeNull();
+  });
+
   it('should expose complete dialog labeling given a trigger and content when the card is open', async () => {
     container = mount(
       <HoverCard defaultOpen>

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -135,6 +135,35 @@ function ControlledToastPressButtonFixture() {
   );
 }
 
+function SiblingToastRegistrationFixture() {
+  const siblingOpen = state(false);
+
+  return (
+    <ToastHost duration={100}>
+      <button
+        id="open-sibling-toast"
+        onClick={() => {
+          siblingOpen.set(true);
+        }}
+      >
+        Open sibling
+      </button>
+      <ToastViewport />
+      <Toast id="original-toast" defaultOpen>
+        <ToastTitle>Original</ToastTitle>
+        <ToastClose>Dismiss original</ToastClose>
+      </Toast>
+      <Toast
+        id="sibling-toast"
+        open={siblingOpen()}
+        onOpenChange={(open) => siblingOpen.set(open)}
+      >
+        <ToastTitle>Sibling</ToastTitle>
+      </Toast>
+    </ToastHost>
+  );
+}
+
 function waitForScheduler(): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(resolve, 20);
@@ -231,6 +260,35 @@ describe('Toast - Behavior', () => {
     await flushUpdates();
 
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(0);
+  });
+
+  it('should preserve an unrelated toast identity and original deadline during sibling registration changes', async () => {
+    vi.useFakeTimers();
+    container = mount(<SiblingToastRegistrationFixture />);
+    await flushUpdates();
+
+    const original = container.querySelector(
+      '#original-toast'
+    ) as HTMLDivElement;
+    const originalClose = original.querySelector('button') as HTMLButtonElement;
+    originalClose.focus();
+
+    await vi.advanceTimersByTimeAsync(60);
+    const launcher = container.querySelector(
+      '#open-sibling-toast'
+    ) as HTMLButtonElement;
+    launcher.click();
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(container.querySelector('#original-toast')).toBe(original);
+    expect(document.activeElement).toBe(originalClose);
+
+    await vi.advanceTimersByTimeAsync(45);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(container.querySelector('#original-toast')).toBeNull();
   });
 
   it('should restore focus after closing a controlled toast', async () => {

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -143,7 +143,7 @@ function SiblingToastRegistrationFixture() {
       <button
         id="open-sibling-toast"
         onClick={() => {
-          siblingOpen.set(true);
+          siblingOpen.set(!siblingOpen());
         }}
       >
         Open sibling
@@ -283,8 +283,18 @@ describe('Toast - Behavior', () => {
 
     expect(container.querySelector('#original-toast')).toBe(original);
     expect(document.activeElement).toBe(originalClose);
+    expect(container.querySelectorAll('#sibling-toast')).toHaveLength(1);
 
-    await vi.advanceTimersByTimeAsync(45);
+    await vi.advanceTimersByTimeAsync(5);
+    launcher.click();
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(container.querySelector('#original-toast')).toBe(original);
+    expect(document.activeElement).toBe(originalClose);
+    expect(container.querySelectorAll('#sibling-toast')).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(40);
     await flushUpdates();
     await flushUpdates();
 

--- a/tests/browser/components/tooltip/behavior.test.tsx
+++ b/tests/browser/components/tooltip/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
 import {
   Tooltip,
@@ -37,6 +38,49 @@ describe('Tooltip - Behavior', () => {
     trigger = container.querySelector('button') as HTMLButtonElement;
 
     expect(trigger.getAttribute('data-state')).toBe('closed');
+  });
+
+  it('should open once from native focus and real keyboard Tab without exhausting the scheduler', async () => {
+    const onOpenChange = vi.fn();
+    container = mount(
+      <>
+        <button data-testid="before">Before</button>
+        <Tooltip onOpenChange={onOpenChange}>
+          <TooltipTrigger>Hover me</TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent>Helpful text</TooltipContent>
+          </TooltipPortal>
+        </Tooltip>
+      </>
+    );
+
+    let trigger = container.querySelector(
+      '[data-slot="tooltip-trigger"]'
+    ) as HTMLButtonElement;
+    expect(() => trigger.focus()).not.toThrow();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="tooltip-trigger"]'
+    ) as HTMLButtonElement;
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute('data-state')).toBe('open');
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+
+    trigger.blur();
+    await flushUpdates();
+    const before = container.querySelector(
+      '[data-testid="before"]'
+    ) as HTMLButtonElement;
+    before.focus();
+    await userEvent.tab();
+    await flushUpdates();
+
+    trigger = container.querySelector(
+      '[data-slot="tooltip-trigger"]'
+    ) as HTMLButtonElement;
+    expect(document.activeElement).toBe(trigger);
+    expect(trigger.getAttribute('data-state')).toBe('open');
   });
 
   it('should keep custom content positioning through the post-open portal sync', async () => {

--- a/tests/browser/components/tooltip/behavior.test.tsx
+++ b/tests/browser/components/tooltip/behavior.test.tsx
@@ -1,5 +1,11 @@
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { Button } from '../../../../src/components/button';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '../../../../src/components/hover-card';
 import {
   Tooltip,
   TooltipContent,
@@ -9,7 +15,7 @@ import {
 import { flushUpdates, mount, unmount } from '../../test-utils';
 
 describe('Tooltip - Behavior', () => {
-  let container: HTMLElement;
+  let container: HTMLElement | undefined;
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -40,19 +46,40 @@ describe('Tooltip - Behavior', () => {
     expect(trigger.getAttribute('data-state')).toBe('closed');
   });
 
-  it('should open once from native focus and real keyboard Tab without exhausting the scheduler', async () => {
+  it('should open once from native focus without exhausting the scheduler', async () => {
     const onOpenChange = vi.fn();
+    const onHoverCardOpenChange = vi.fn();
     container = mount(
       <>
-        <button data-testid="before">Before</button>
+        <button data-testid="before" tabIndex={0}>
+          Before
+        </button>
+        <Button data-testid="button-control">Button control</Button>
+        <HoverCard onOpenChange={onHoverCardOpenChange}>
+          <HoverCardTrigger>HoverCard control</HoverCardTrigger>
+          <HoverCardContent>HoverCard content</HoverCardContent>
+        </HoverCard>
         <Tooltip onOpenChange={onOpenChange}>
-          <TooltipTrigger>Hover me</TooltipTrigger>
+          <TooltipTrigger tabIndex={0}>Hover me</TooltipTrigger>
           <TooltipPortal>
             <TooltipContent>Helpful text</TooltipContent>
           </TooltipPortal>
         </Tooltip>
       </>
     );
+
+    const buttonControl = container.querySelector(
+      '[data-testid="button-control"]'
+    ) as HTMLButtonElement;
+    expect(() => buttonControl.focus()).not.toThrow();
+    expect(document.activeElement).toBe(buttonControl);
+
+    const hoverCardControl = container.querySelector(
+      '[data-slot="hover-card-trigger"]'
+    ) as HTMLButtonElement;
+    expect(() => hoverCardControl.focus()).not.toThrow();
+    await flushUpdates();
+    expect(onHoverCardOpenChange).toHaveBeenCalledTimes(1);
 
     let trigger = container.querySelector(
       '[data-slot="tooltip-trigger"]'
@@ -66,21 +93,85 @@ describe('Tooltip - Behavior', () => {
     expect(document.activeElement).toBe(trigger);
     expect(trigger.getAttribute('data-state')).toBe('open');
     expect(onOpenChange).toHaveBeenCalledTimes(1);
+  });
 
-    trigger.blur();
-    await flushUpdates();
+  it('should open from a real keyboard Tab and preserve focus on the trigger', async () => {
+    const onOpenChange = vi.fn();
+    container = mount(
+      <>
+        <button data-testid="before" tabIndex={0}>
+          Before
+        </button>
+        <Tooltip onOpenChange={onOpenChange}>
+          <TooltipTrigger tabIndex={0}>Hover me</TooltipTrigger>
+          <TooltipPortal>
+            <TooltipContent>Helpful text</TooltipContent>
+          </TooltipPortal>
+        </Tooltip>
+      </>
+    );
+
     const before = container.querySelector(
       '[data-testid="before"]'
     ) as HTMLButtonElement;
     before.focus();
+    expect(document.activeElement).toBe(before);
     await userEvent.tab();
     await flushUpdates();
 
-    trigger = container.querySelector(
+    const trigger = container.querySelector(
       '[data-slot="tooltip-trigger"]'
     ) as HTMLButtonElement;
+    expect(onOpenChange.mock.calls).toEqual([[true]]);
     expect(document.activeElement).toBe(trigger);
     expect(trigger.getAttribute('data-state')).toBe('open');
+  });
+
+  it('should keep a controlled native-focus request bounded when the owner does not accept it', async () => {
+    const onOpenChange = vi.fn();
+    container = mount(
+      <Tooltip open={false} onOpenChange={onOpenChange}>
+        <TooltipTrigger>Hover me</TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent>Helpful text</TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="tooltip-trigger"]'
+    ) as HTMLButtonElement;
+    expect(() => trigger.focus()).not.toThrow();
+    await flushUpdates();
+
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+    expect(trigger.getAttribute('data-state')).toBe('closed');
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  it('should cancel pending focus-adoption work during teardown', async () => {
+    const cancelFrame = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {});
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 73);
+    container = mount(
+      <Tooltip>
+        <TooltipTrigger>Hover me</TooltipTrigger>
+        <TooltipPortal>
+          <TooltipContent>Helpful text</TooltipContent>
+        </TooltipPortal>
+      </Tooltip>
+    );
+
+    const trigger = container.querySelector(
+      '[data-slot="tooltip-trigger"]'
+    ) as HTMLButtonElement;
+    trigger.focus();
+    await flushUpdates();
+    unmount(container);
+    container = undefined;
+
+    expect(cancelFrame).toHaveBeenCalledWith(73);
   });
 
   it('should keep custom content positioning through the post-open portal sync', async () => {

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -121,4 +121,50 @@ describe('Source layout', () => {
     expect(identitySource).toContain("addEventListener(\n    'abort'");
     expect(identitySource).not.toMatch(/Math\.random|randomUUID/);
   });
+
+  it('should keep async interaction families on lifecycle-specific browser guardrails', () => {
+    const componentsDirectory = join(process.cwd(), 'src', 'components');
+    const browserDirectory = join(
+      process.cwd(),
+      'tests',
+      'browser',
+      'components'
+    );
+    const hoverCardSuite = readFileSync(
+      join(browserDirectory, 'hover-card', 'behavior.test.tsx'),
+      'utf8'
+    );
+    expect(hoverCardSuite).toContain('pointer leaves immediately');
+    expect(hoverCardSuite).toContain('pointer re-enters before its deadline');
+    expect(hoverCardSuite).toContain('repeated timer churn');
+    expect(hoverCardSuite).toContain('both transition timers during teardown');
+
+    const tooltipSuite = readFileSync(
+      join(browserDirectory, 'tooltip', 'behavior.test.tsx'),
+      'utf8'
+    );
+    expect(tooltipSuite).toContain('trigger.focus()');
+    expect(tooltipSuite).toContain('await userEvent.tab()');
+    expect(tooltipSuite).toContain('Button control');
+    expect(tooltipSuite).toContain('HoverCard control');
+    expect(tooltipSuite).toContain('controlled native-focus request bounded');
+    expect(tooltipSuite).toContain('focus-adoption work during teardown');
+
+    const toastSuite = readFileSync(
+      join(browserDirectory, 'toast', 'behavior.test.tsx'),
+      'utf8'
+    );
+    expect(toastSuite).toContain('original deadline during sibling');
+    expect(toastSuite).toContain('toBe(original)');
+    expect(toastSuite).toContain('toBe(originalClose)');
+
+    const toastSource = readFileSync(
+      join(componentsDirectory, 'toast', 'toast.tsx'),
+      'utf8'
+    );
+    expect(toastSource).toContain('<For each={host.getToasts}');
+    expect(toastSource).toContain(
+      'by={(registration) => registration.toastId}'
+    );
+  });
 });

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -138,6 +138,17 @@ describe('Source layout', () => {
     expect(hoverCardSuite).toContain('pointer re-enters before its deadline');
     expect(hoverCardSuite).toContain('repeated timer churn');
     expect(hoverCardSuite).toContain('both transition timers during teardown');
+    expect(hoverCardSuite).toContain('userEvent.hover(getPointerExitTarget())');
+
+    const hoverCardSource = readFileSync(
+      join(componentsDirectory, 'hover-card', 'hover-card.tsx'),
+      'utf8'
+    );
+    expect(hoverCardSource).toContain("addEventListener('pointerover'");
+    expect(hoverCardSource).toContain(
+      "removeEventListener(\n            'pointerover'"
+    );
+    expect(hoverCardSource).toContain('clearOpenTimer()');
 
     const tooltipSuite = readFileSync(
       join(browserDirectory, 'tooltip', 'behavior.test.tsx'),

--- a/vitest.test.browser.config.ts
+++ b/vitest.test.browser.config.ts
@@ -4,6 +4,9 @@ import { sharedVitestConfig } from './vitest.test.shared';
 
 export default defineConfig({
   ...sharedVitestConfig,
+  optimizeDeps: {
+    include: ['@askrjs/askr/testing'],
+  },
   test: {
     ...sharedVitestConfig.test,
     setupFiles: [


### PR DESCRIPTION
Closes #55.
Closes #56.
Closes #57.

## Summary

- make HoverCard open/close scheduling mutually exclusive and clear both timer directions on teardown
- bound Tooltip native-focus adoption across reactive trigger replacement without emitting idempotent controlled updates
- key Toast registrations by `toastId` so sibling churn preserves unrelated component, timer, DOM, and focus identity
- add lifecycle-specific source guards and three-engine browser regressions
- release `@askrjs/ui@0.0.31`

## TDD evidence

- Red `cf7bdf42a7bd863c231a6d1c900f53c1432fbfae`: the focused suite failed 11 cases across Chromium, Firefox, and WebKit. HoverCard opened after immediate leave and closed after re-entry; sibling Toast registration replaced the original node; native Tooltip focus exhausted `MAX_FLUSH_DEPTH` while producing 101 alternating `onOpenChange` transitions.
- Green `e3580e38d39acda56b67cc30804caad6af7c9442`: 9 focused files / 90 tests passed across all three engines, then passed three more consecutive focused runs.
- Hosted red runs `31912365725`, `31912781455`, `31913025321`, `31913224799`, `31913596839`, and `31914105719` first exposed stale-node, event-delivery, and scheduler-phase timing under Ubuntu load, then isolated a product defect: reconciliation can replace a hovered trigger while the pointer remains stationary, so no leave event reaches the replacement node. Red `d9628e5558ebc8a611e605047ac5f2ee3a90dad1` reproduces that path with real `userEvent.hover()` pointer movement and a visible outside target. Green `c25fd1f18adff4f35456b3adf96eadb715067a70` passed the focused suite across Chromium, Firefox, and WebKit five consecutive times before the full gate. Exact-head run `31914542143` then showed the five-cycle real-pointer churn guard repeatedly exceeded the global 15-second test deadline under Windows browser load before reaching its assertion. Test guard `ec6a266f4a877d25d4a96e89b35a757bf31b8825` keeps three complete churn cycles, adds an exact single-open transition assertion, and passes the focused suite in all three engines.
- Full local gate: `npm run check` passed 309 browser files / 1,275 browser tests plus build, lint, types, unit, policy, jsdom, publint, and packed-consumer validation.
- All four benchmark tiers passed, including three-engine Tooltip and Toast lifecycle tiers; `npm audit --omit=dev` reported 0 vulnerabilities.

## Root cause and permanent guardrails

- HoverCard independently scheduled opposing timers, and an older callback could clear or overwrite the newer transition. Separate timer cancellation functions now enforce one pending direction. A lifecycle-owned document `pointerover` guard also evaluates the live trigger/content containment after reconciliation, clears a pending open outside, schedules at most one close for an open card, cancels that close on re-entry, and is removed on teardown. Immediate-leave, re-entry, three-cycle repeated churn with exactly one final open, transfer/focus, reconciled-node pointer exit, and listener-cleanup regressions exercise real user pointer movement across all three engines; the source-layout guard requires both installation and cleanup of the structural listener.
- Tooltip native focus synchronously opened the root; reconciliation replaced the focused trigger, whose blur attempted to close the root and restarted the open/close render cycle. A bounded focus-adoption episode ignores only that replacement blur, re-focuses the live trigger, suppresses idempotent updates, and cancels pending frame work on teardown. Native `.focus()`, real Tab, plain-control, controlled-rejection, and teardown regressions are mandatory in source-layout CI.
- Toast rendered registrations with a raw reactive array map, so any sibling registration change recreated unrelated views. Keyed `<For>` reconciliation now preserves each `toastId`; CI asserts unrelated DOM identity, focus identity, and original expiry deadline through sibling open/close churn.

## Acceptance audit

- [x] Reporter ownership and issue contracts were read back from GitHub and clarified against the supported APIs.
- [x] Regression tests were committed red before implementation.
- [x] The same focused regressions pass green and repeatedly across Chromium, Firefox, and WebKit.
- [x] Permanent structural and behavioral guardrails cover race direction, keyed identity, real native focus, controlled rejection, and teardown.
- [x] Full local release, package, benchmark, and production-audit gates pass.
- [x] Exact-head hosted CI succeeds on macOS, Windows, and Ubuntu.
- [x] Every linked issue acceptance checkbox is checked with evidence before ready-for-review and squash merge.
- [x] `v0.0.31` peels to the squash-merged main SHA, npm integrity is verified, and a clean consumer imports the repaired surfaces with a zero-vulnerability production audit.
