### PR TITLE
fix: harden virtualization scroll and resize lifecycle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/virtual-list/virtual-list.tsx
+++ b/src/components/virtual-list/virtual-list.tsx
@@ -52,6 +52,7 @@ type VirtualListEntry<Item> = {
   pendingUnseenCount: number;
   pendingScrollTop: number | null;
   pendingCommitFrame: number | null;
+  resizeCommitFrame: number | null;
   resizeObserver: ResizeObserver | null;
   windowResizeHandler: (() => void) | null;
   rootRef: (node: HTMLElement | null) => void;
@@ -118,13 +119,19 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
   };
 
   const applyPendingScrollTop = () => {
-    const nextScrollTop = entry.pendingScrollTop;
+    const pendingScrollTop = entry.pendingScrollTop;
     const node = entry.node;
 
-    if (nextScrollTop === null || !node) {
+    if (pendingScrollTop === null || !node) {
       return;
     }
 
+    const viewportHeight = readViewportHeight() || entry.viewportHeightHint;
+    const maxScrollTop = resolveVirtualScrollTopForBottom(
+      resolveVirtualTotalHeight(entry.keys.length, entry.rowHeight),
+      viewportHeight
+    );
+    const nextScrollTop = Math.min(Math.max(0, pendingScrollTop), maxScrollTop);
     entry.pendingScrollTop = null;
 
     if (node.scrollTop !== nextScrollTop) {
@@ -176,6 +183,14 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
     // Read the live scroll position from the viewport so visible range math
     // stays aligned with the browser's actual scroll state.
     const nextScrollTop = node.scrollTop;
+
+    if (event && entry.pendingScrollTop !== null) {
+      entry.pendingScrollTop = null;
+      if (entry.pendingCommitFrame !== null) {
+        cancelAnimationFrame(entry.pendingCommitFrame);
+        entry.pendingCommitFrame = null;
+      }
+    }
 
     if (readScrollTop() !== nextScrollTop) {
       setScrollTop(nextScrollTop);
@@ -258,6 +273,29 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
     bumpRenderVersion();
   };
 
+  const scheduleResize = () => {
+    if (entry.resizeCommitFrame !== null) {
+      return;
+    }
+
+    if (typeof requestAnimationFrame !== 'function') {
+      entry.resizeCommitFrame = -1;
+      queueMicrotask(() => {
+        entry.resizeCommitFrame = null;
+        handleResize();
+      });
+      return;
+    }
+
+    // ResizeObserver callbacks are measurement-only. Defer every state/DOM
+    // write until the next frame so the observer delivery cannot feed back
+    // into the same browser resize cycle.
+    entry.resizeCommitFrame = requestAnimationFrame(() => {
+      entry.resizeCommitFrame = null;
+      handleResize();
+    });
+  };
+
   const rootRef = (node: HTMLElement | null) => {
     setRefValue(entry.userRef, node);
 
@@ -268,6 +306,13 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
     if (entry.pendingCommitFrame !== null) {
       cancelAnimationFrame(entry.pendingCommitFrame);
       entry.pendingCommitFrame = null;
+    }
+
+    if (entry.resizeCommitFrame !== null) {
+      if (entry.resizeCommitFrame >= 0) {
+        cancelAnimationFrame(entry.resizeCommitFrame);
+      }
+      entry.resizeCommitFrame = null;
     }
 
     entry.resizeObserver?.disconnect();
@@ -306,7 +351,7 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
 
       if (typeof ResizeObserver !== 'undefined') {
         entry.resizeObserver = new ResizeObserver(() => {
-          handleResize();
+          scheduleResize();
         });
         entry.resizeObserver.observe(node);
       } else {
@@ -447,6 +492,7 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
   entry.pendingUnseenCount = entry.pendingUnseenCount ?? 0;
   entry.pendingScrollTop = entry.pendingScrollTop ?? null;
   entry.pendingCommitFrame = entry.pendingCommitFrame ?? null;
+  entry.resizeCommitFrame = entry.resizeCommitFrame ?? null;
   entry.visibleRange =
     entry.visibleRange ??
     resolveVirtualRange({
@@ -508,6 +554,30 @@ function renderVirtualListRows<Item>(
 
   const RowHost = rendersSemanticListItems ? 'li' : 'div';
 
+  const pushSpacer = (position: 'before' | 'after', height: number) => {
+    if (height <= 0) {
+      return;
+    }
+
+    rows.push(
+      <RowHost
+        key={`virtual-list-spacer-${position}`}
+        aria-hidden="true"
+        data-slot="virtual-list-spacer"
+        data-position={position}
+        style={{
+          height: `${height}px`,
+          listStyle: 'none',
+          flex: '0 0 auto',
+          overflow: 'hidden',
+          pointerEvents: 'none',
+        }}
+      />
+    );
+  };
+
+  pushSpacer('before', visibleRange.beforeSpacerHeight);
+
   for (
     let index = visibleRange.renderStartIndex;
     index <= visibleRange.renderEndIndex;
@@ -534,6 +604,7 @@ function renderVirtualListRows<Item>(
           height: `${entry.rowHeight}px`,
           listStyle: 'none',
           flex: '0 0 auto',
+          overflow: 'hidden',
         }}
       >
         <RowComponent
@@ -545,6 +616,8 @@ function renderVirtualListRows<Item>(
       </RowHost>
     );
   }
+
+  pushSpacer('after', visibleRange.afterSpacerHeight);
 
   return rows;
 }
@@ -639,12 +712,14 @@ function syncVirtualListItems<Item>(
   entry.keyIndexMap = nextKeyIndexMap;
   entry.itemsRef = items;
 
-  if (entry.pendingScrollTop === null) {
-    entry.pendingScrollTop = Math.min(
-      currentScrollTop,
-      resolveVirtualScrollTopForBottom(nextTotalHeight, currentViewportHeight)
-    );
-  }
+  const maxScrollTop = resolveVirtualScrollTopForBottom(
+    nextTotalHeight,
+    currentViewportHeight
+  );
+  entry.pendingScrollTop = Math.min(
+    Math.max(0, entry.pendingScrollTop ?? currentScrollTop),
+    maxScrollTop
+  );
 
   if (entry.pendingScrollTop !== null) {
     entry.schedulePendingScrollTop();

--- a/src/components/virtual-table/virtual-table.tsx
+++ b/src/components/virtual-table/virtual-table.tsx
@@ -49,6 +49,7 @@ type VirtualTableEntry<Row> = {
   keyIndexMap: Map<string, number>;
   pendingScrollTop: number | null;
   pendingCommitFrame: number | null;
+  resizeCommitFrame: number | null;
   resizeObserver: ResizeObserver | null;
   windowResizeHandler: (() => void) | null;
   rootRef: (node: HTMLElement | null) => void;
@@ -96,13 +97,23 @@ function getVirtualTableEntry<Row>(
   const entry = {} as VirtualTableEntry<Row>;
 
   const applyPendingScrollTop = () => {
-    const nextScrollTop = entry.pendingScrollTop;
+    const pendingScrollTop = entry.pendingScrollTop;
     const node = entry.wrapperNode;
 
-    if (nextScrollTop === null || !node) {
+    if (pendingScrollTop === null || !node) {
       return;
     }
 
+    const viewportHeight =
+      entry.viewportHeightState() || entry.viewportHeightHint;
+    const bodyViewportHeight = Math.max(0, viewportHeight - entry.headerHeight);
+    const maxScrollTop =
+      entry.headerHeight +
+      resolveVirtualScrollTopForBottom(
+        resolveVirtualTotalHeight(entry.keys.length, entry.rowHeight),
+        bodyViewportHeight
+      );
+    const nextScrollTop = Math.min(Math.max(0, pendingScrollTop), maxScrollTop);
     entry.pendingScrollTop = null;
 
     if (node.scrollTop !== nextScrollTop) {
@@ -144,6 +155,14 @@ function getVirtualTableEntry<Row>(
     // Read the live scroll position from the wrapper so the table window math
     // stays aligned with the browser's actual scroll state.
     const nextScrollTop = node.scrollTop;
+
+    if (event && entry.pendingScrollTop !== null) {
+      entry.pendingScrollTop = null;
+      if (entry.pendingCommitFrame !== null) {
+        cancelAnimationFrame(entry.pendingCommitFrame);
+        entry.pendingCommitFrame = null;
+      }
+    }
 
     if (scrollTopState() !== nextScrollTop) {
       scrollTopState.set(nextScrollTop);
@@ -189,6 +208,29 @@ function getVirtualTableEntry<Row>(
         scrollTopState.set(maxScrollTop);
       }
     }
+  };
+
+  const scheduleResize = () => {
+    if (entry.resizeCommitFrame !== null) {
+      return;
+    }
+
+    if (typeof requestAnimationFrame !== 'function') {
+      entry.resizeCommitFrame = -1;
+      queueMicrotask(() => {
+        entry.resizeCommitFrame = null;
+        handleResize();
+      });
+      return;
+    }
+
+    // ResizeObserver callbacks are measurement-only. Defer every state/DOM
+    // write until the next frame so the observer delivery cannot feed back
+    // into the same browser resize cycle.
+    entry.resizeCommitFrame = requestAnimationFrame(() => {
+      entry.resizeCommitFrame = null;
+      handleResize();
+    });
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -258,6 +300,13 @@ function getVirtualTableEntry<Row>(
       entry.pendingCommitFrame = null;
     }
 
+    if (entry.resizeCommitFrame !== null) {
+      if (entry.resizeCommitFrame >= 0) {
+        cancelAnimationFrame(entry.resizeCommitFrame);
+      }
+      entry.resizeCommitFrame = null;
+    }
+
     entry.resizeObserver?.disconnect();
     entry.resizeObserver = null;
 
@@ -293,7 +342,7 @@ function getVirtualTableEntry<Row>(
 
       if (typeof ResizeObserver !== 'undefined') {
         entry.resizeObserver = new ResizeObserver(() => {
-          handleResize();
+          scheduleResize();
         });
         entry.resizeObserver.observe(node);
       } else {
@@ -418,12 +467,13 @@ function getVirtualTableEntry<Row>(
     getState() {
       const visibleRange = entry.visibleRange;
       const selectedKey = entry.selectedKeyState();
+      const scrollTop = entry.pendingScrollTop ?? scrollTopState();
 
       return {
         count: entry.keys.length,
         rowHeight: entry.rowHeight,
         headerHeight: entry.headerHeight,
-        scrollTop: scrollTopState(),
+        scrollTop,
         viewportHeight: viewportHeightState(),
         totalHeight:
           resolveVirtualTotalHeight(entry.keys.length, entry.rowHeight) +
@@ -445,7 +495,7 @@ function getVirtualTableEntry<Row>(
       return entry.keys.length;
     },
     getScrollTop() {
-      return scrollTopState();
+      return entry.pendingScrollTop ?? scrollTopState();
     },
     isAtTop() {
       return entry.visibleRange.isAtTop;
@@ -499,6 +549,7 @@ function getVirtualTableEntry<Row>(
   entry.keyIndexMap = entry.keyIndexMap ?? new Map<string, number>();
   entry.pendingScrollTop = entry.pendingScrollTop ?? null;
   entry.pendingCommitFrame = entry.pendingCommitFrame ?? null;
+  entry.resizeCommitFrame = entry.resizeCommitFrame ?? null;
   entry.visibleRange =
     entry.visibleRange ??
     resolveVirtualRange({
@@ -609,16 +660,16 @@ function syncVirtualTableRows<Row>(
     }
   }
 
-  if (entry.pendingScrollTop === null) {
-    const maxScrollTop =
-      entry.headerHeight +
-      resolveVirtualScrollTopForBottom(
-        nextBodyTotalHeight,
-        currentBodyViewportHeight
-      );
-
-    entry.pendingScrollTop = Math.min(currentScrollTop, maxScrollTop);
-  }
+  const maxScrollTop =
+    entry.headerHeight +
+    resolveVirtualScrollTopForBottom(
+      nextBodyTotalHeight,
+      currentBodyViewportHeight
+    );
+  entry.pendingScrollTop = Math.min(
+    Math.max(0, entry.pendingScrollTop ?? currentScrollTop),
+    maxScrollTop
+  );
 
   entry.keys = nextKeys;
   entry.keyIndexMap = nextKeyIndexMap;
@@ -743,7 +794,7 @@ function renderVirtualTableRows<Row>(
         data-selected={selected ? 'true' : 'false'}
         aria-rowindex={index + 1}
         aria-selected={selected ? 'true' : 'false'}
-        style={{ height: `${entry.rowHeight}px` }}
+        style={{ height: `${entry.rowHeight}px`, overflow: 'hidden' }}
         onClick={(event: MouseEvent) => {
           onRowClick(row, index, rowKey, event);
         }}
@@ -756,14 +807,30 @@ function renderVirtualTableRows<Row>(
               key={column.id}
               data-slot="virtual-table-cell"
               data-column-id={column.id}
+              style={{
+                boxSizing: 'border-box',
+                height: `${entry.rowHeight}px`,
+                maxHeight: `${entry.rowHeight}px`,
+                overflow: 'hidden',
+                position: 'relative',
+              }}
             >
-              <CellComponent
-                row={row}
-                rowIndex={index}
-                rowKey={rowKey}
-                column={column}
-                selected={selected}
-              />
+              <div
+                data-slot="virtual-table-cell-content"
+                style={{
+                  inset: 0,
+                  overflow: 'hidden',
+                  position: 'absolute',
+                }}
+              >
+                <CellComponent
+                  row={row}
+                  rowIndex={index}
+                  rowKey={rowKey}
+                  column={column}
+                  selected={selected}
+                />
+              </div>
             </td>
           );
         })}
@@ -992,7 +1059,14 @@ export function VirtualTable<Row>(
   );
 
   const tableBody = (
-    <table {...tableProps} style={{ tableLayout: 'fixed' }}>
+    <table
+      {...tableProps}
+      style={{
+        borderCollapse: 'collapse',
+        borderSpacing: 0,
+        tableLayout: 'fixed',
+      }}
+    >
       {columnsMarkup.length > 0 ? <colgroup>{columnsMarkup}</colgroup> : null}
       {headerMarkup}
       <tbody data-slot="virtual-table-body">{rowsMarkup}</tbody>

--- a/tests/browser/components/virtual-list/behavior.test.tsx
+++ b/tests/browser/components/virtual-list/behavior.test.tsx
@@ -18,6 +18,12 @@ function createItems(count: number): Item[] {
   }));
 }
 
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
+
 describe('VirtualList - Behavior', () => {
   let container: HTMLElement | undefined;
 
@@ -174,5 +180,111 @@ describe('VirtualList - Behavior', () => {
     await flushUpdates();
 
     expect(onScroll).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reserve the full native scroll extent and advance from browser scrolling', async () => {
+    let api: VirtualListApi<Item> | null = null;
+
+    container = mount(
+      <VirtualList
+        aria-label="Large messages"
+        style={{ height: '200px', overflowY: 'auto' }}
+        items={createItems(10_000)}
+        rowHeight={20}
+        getKey={(item) => item.id}
+        rowComponent={({ item }) => <span>{item.label}</span>}
+        apiRef={(next) => {
+          api = next;
+        }}
+      />
+    );
+    await flushUpdates();
+
+    const host = container.querySelector(
+      '[data-slot="virtual-list"]'
+    ) as HTMLElement;
+
+    expect(host.scrollHeight).toBe(200_000);
+
+    host.scrollTop = 20_000;
+    host.dispatchEvent(new Event('scroll', { bubbles: true }));
+    await flushUpdates();
+
+    expect(host.scrollTop).toBeCloseTo(20_000, 0);
+    expect(api?.getVisibleRange().visibleStartIndex).toBe(1_000);
+  });
+
+  it('should report no ResizeObserver loop errors during dynamic resize churn', async () => {
+    const resizeErrors: string[] = [];
+    const onWindowError = (event: ErrorEvent) => {
+      if (event.message.includes('ResizeObserver loop')) {
+        resizeErrors.push(event.message);
+        event.preventDefault();
+      }
+    };
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation((...values: unknown[]) => {
+        const message = values.map(String).join(' ');
+        if (message.includes('ResizeObserver loop')) resizeErrors.push(message);
+      });
+    window.addEventListener('error', onWindowError);
+
+    try {
+      container = mount(
+        <VirtualList
+          aria-label="Resizable messages"
+          style={{ height: '100px', overflowY: 'auto' }}
+          items={createItems(1_000)}
+          rowHeight={20}
+          getKey={(item) => item.id}
+          rowComponent={({ item }) => <span>{item.label}</span>}
+        />
+      );
+      await flushUpdates();
+
+      const host = container.querySelector(
+        '[data-slot="virtual-list"]'
+      ) as HTMLElement;
+      host.scrollTop = 10_000;
+      host.dispatchEvent(new Event('scroll', { bubbles: true }));
+
+      for (const height of [0, 50, 400, 1, 10_000, 0, 300]) {
+        host.style.height = `${height}px`;
+        await nextAnimationFrame();
+      }
+      await nextAnimationFrame();
+
+      expect(resizeErrors).toEqual([]);
+    } finally {
+      window.removeEventListener('error', onWindowError);
+      consoleError.mockRestore();
+    }
+  });
+
+  it('should contain content within its fixed row-height contract', async () => {
+    container = mount(
+      <VirtualList
+        aria-label="Overflowing messages"
+        style={{ height: '40px', overflowY: 'auto' }}
+        items={createItems(2)}
+        rowHeight={20}
+        getKey={(item) => item.id}
+        rowComponent={({ item }) => (
+          <div style={{ height: '200px' }}>{item.label}</div>
+        )}
+      />
+    );
+    await flushUpdates();
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-slot="virtual-list-row"]')
+    );
+    const firstBox = rows[0].getBoundingClientRect();
+    const secondBox = rows[1].getBoundingClientRect();
+
+    expect(getComputedStyle(rows[0]).overflowY).toBe('hidden');
+    expect(firstBox.height).toBeCloseTo(20, 0);
+    expect(secondBox.top - firstBox.top).toBeCloseTo(20, 0);
   });
 });

--- a/tests/browser/components/virtual-list/behavior.test.tsx
+++ b/tests/browser/components/virtual-list/behavior.test.tsx
@@ -214,6 +214,51 @@ describe('VirtualList - Behavior', () => {
     expect(api?.getVisibleRange().visibleStartIndex).toBe(1_000);
   });
 
+  it('should clamp a pending scroll commit when its dataset is replaced', async () => {
+    let api: VirtualListApi<Item> | null = null;
+    let replaceItems: (() => void) | undefined;
+
+    const FilterableList = () => {
+      const itemsState = state(createItems(5_000));
+      replaceItems = () => {
+        itemsState.set(
+          Array.from({ length: 20 }, (_, index) => ({
+            id: `filtered-item-${index}`,
+            label: `Filtered ${index}`,
+          }))
+        );
+      };
+
+      return (
+        <VirtualList
+          aria-label="Filterable messages"
+          style={{ height: '100px', overflowY: 'auto' }}
+          items={itemsState()}
+          rowHeight={20}
+          getKey={(item) => item.id}
+          rowComponent={({ item }) => <span>{item.label}</span>}
+          apiRef={(next) => {
+            api = next;
+          }}
+        />
+      );
+    };
+
+    container = mount(<FilterableList />);
+    await flushUpdates();
+
+    api?.scrollToIndex(4_000, 'start');
+    replaceItems?.();
+    await flushUpdates();
+
+    const maximumScrollTop = 20 * 20 - 100;
+    expect(api?.getScrollTop()).toBeLessThanOrEqual(maximumScrollTop);
+
+    await nextAnimationFrame();
+
+    expect(api?.getScrollTop()).toBeLessThanOrEqual(maximumScrollTop);
+  });
+
   it('should report no ResizeObserver loop errors during dynamic resize churn', async () => {
     const resizeErrors: string[] = [];
     const onWindowError = (event: ErrorEvent) => {

--- a/tests/browser/components/virtual-table/behavior.test.tsx
+++ b/tests/browser/components/virtual-table/behavior.test.tsx
@@ -234,12 +234,14 @@ describe('VirtualTable - Behavior', () => {
     api?.scrollToIndex(4_000, 'start');
     replaceRows?.();
     await flushUpdates();
+    await flushUpdates();
 
     const wrapper = container.querySelector(
       '[data-slot="virtual-table"]'
     ) as HTMLElement;
     const maximumScrollTop = 24 + (20 * 24 - (120 - 24));
 
+    expect(api?.getRowCount()).toBe(20);
     expect(api?.getScrollTop()).toBeLessThanOrEqual(maximumScrollTop);
 
     await nextAnimationFrame();
@@ -327,11 +329,16 @@ describe('VirtualTable - Behavior', () => {
     const firstCell = rows[0].querySelector<HTMLElement>(
       '[data-slot="virtual-table-cell"]'
     );
+    const firstCellContent = rows[0].querySelector<HTMLElement>(
+      '[data-slot="virtual-table-cell-content"]'
+    );
     const firstBox = rows[0].getBoundingClientRect();
     const secondBox = rows[1].getBoundingClientRect();
 
-    expect(getComputedStyle(rows[0]).overflowY).toBe('hidden');
     expect(firstCell && getComputedStyle(firstCell).overflowY).toBe('hidden');
+    expect(
+      firstCellContent && getComputedStyle(firstCellContent).overflowY
+    ).toBe('hidden');
     expect(firstBox.height).toBeCloseTo(24, 0);
     expect(secondBox.top - firstBox.top).toBeCloseTo(24, 0);
   });

--- a/tests/browser/components/virtual-table/behavior.test.tsx
+++ b/tests/browser/components/virtual-table/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { state } from '@askrjs/askr';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   VirtualTable,
@@ -32,6 +33,12 @@ const columns: readonly VirtualTableColumn<Row>[] = [
     cellComponent: ({ row }) => <span>{row.email}</span>,
   },
 ];
+
+function nextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+}
 
 describe('VirtualTable - Behavior', () => {
   let container: HTMLElement | undefined;
@@ -187,5 +194,145 @@ describe('VirtualTable - Behavior', () => {
     // Firefox can expose a subpixel scroll offset after layout. The public
     // contract is the requested logical position, not engine-specific rounding.
     expect(api?.getScrollTop()).toBeCloseTo(72, 0);
+  });
+
+  it('should clamp a pending scroll commit when its dataset is replaced', async () => {
+    let api: VirtualTableApi<Row> | null = null;
+    let replaceRows: (() => void) | undefined;
+
+    const FilterableTable = () => {
+      const rowsState = state(createRows(5_000));
+      replaceRows = () => {
+        rowsState.set(
+          Array.from({ length: 20 }, (_, index) => ({
+            id: `filtered-row-${index}`,
+            name: `Filtered ${index}`,
+            email: `filtered-${index}@example.com`,
+          }))
+        );
+      };
+
+      return (
+        <VirtualTable
+          aria-label="Filterable users"
+          style={{ height: '120px', overflowY: 'auto' }}
+          rows={rowsState()}
+          rowHeight={24}
+          headerHeight={24}
+          getKey={(row) => row.id}
+          columns={columns}
+          apiRef={(next) => {
+            api = next;
+          }}
+        />
+      );
+    };
+
+    container = mount(<FilterableTable />);
+    await flushUpdates();
+
+    api?.scrollToIndex(4_000, 'start');
+    replaceRows?.();
+    await flushUpdates();
+
+    const wrapper = container.querySelector(
+      '[data-slot="virtual-table"]'
+    ) as HTMLElement;
+    const maximumScrollTop = 24 + (20 * 24 - (120 - 24));
+
+    expect(api?.getScrollTop()).toBeLessThanOrEqual(maximumScrollTop);
+
+    await nextAnimationFrame();
+
+    expect(api?.getScrollTop()).toBeLessThanOrEqual(maximumScrollTop);
+    expect(wrapper.scrollTop).toBeLessThanOrEqual(maximumScrollTop);
+  });
+
+  it('should report no ResizeObserver loop errors during dynamic resize churn', async () => {
+    const resizeErrors: string[] = [];
+    const onWindowError = (event: ErrorEvent) => {
+      if (event.message.includes('ResizeObserver loop')) {
+        resizeErrors.push(event.message);
+        event.preventDefault();
+      }
+    };
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation((...values: unknown[]) => {
+        const message = values.map(String).join(' ');
+        if (message.includes('ResizeObserver loop')) resizeErrors.push(message);
+      });
+    window.addEventListener('error', onWindowError);
+
+    try {
+      container = mount(
+        <VirtualTable
+          aria-label="Resizable users"
+          style={{ height: '120px', overflowY: 'auto' }}
+          rows={createRows(1_000)}
+          rowHeight={24}
+          headerHeight={24}
+          getKey={(row) => row.id}
+          columns={columns}
+        />
+      );
+      await flushUpdates();
+
+      const wrapper = container.querySelector(
+        '[data-slot="virtual-table"]'
+      ) as HTMLElement;
+      wrapper.scrollTop = 10_000;
+      wrapper.dispatchEvent(new Event('scroll', { bubbles: true }));
+
+      for (const height of [0, 50, 400, 1, 10_000, 0, 300]) {
+        wrapper.style.height = `${height}px`;
+        await nextAnimationFrame();
+      }
+      await nextAnimationFrame();
+
+      expect(resizeErrors).toEqual([]);
+    } finally {
+      window.removeEventListener('error', onWindowError);
+      consoleError.mockRestore();
+    }
+  });
+
+  it('should contain content within its fixed row-height contract', async () => {
+    const overflowColumns: readonly VirtualTableColumn<Row>[] = [
+      {
+        id: 'name',
+        header: 'Name',
+        cellComponent: ({ row }) => (
+          <div style={{ height: '200px' }}>{row.name}</div>
+        ),
+      },
+    ];
+
+    container = mount(
+      <VirtualTable
+        aria-label="Overflowing users"
+        style={{ height: '72px', overflowY: 'auto' }}
+        rows={createRows(2)}
+        rowHeight={24}
+        headerHeight={24}
+        getKey={(row) => row.id}
+        columns={overflowColumns}
+      />
+    );
+    await flushUpdates();
+
+    const rows = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-slot="virtual-table-row"]')
+    );
+    const firstCell = rows[0].querySelector<HTMLElement>(
+      '[data-slot="virtual-table-cell"]'
+    );
+    const firstBox = rows[0].getBoundingClientRect();
+    const secondBox = rows[1].getBoundingClientRect();
+
+    expect(getComputedStyle(rows[0]).overflowY).toBe('hidden');
+    expect(firstCell && getComputedStyle(firstCell).overflowY).toBe('hidden');
+    expect(firstBox.height).toBeCloseTo(24, 0);
+    expect(secondBox.top - firstBox.top).toBeCloseTo(24, 0);
   });
 });


### PR DESCRIPTION
Closes #51.
Closes #52.
Closes #53.
Closes #61.

## Summary

- give `VirtualList` explicit before/after spacers so native scrolling owns the full virtual extent
- clamp deferred scroll writes against the current dataset both when data changes and when the write is consumed
- make real user scroll events supersede stale programmatic commits in `VirtualList` and `VirtualTable`
- move ResizeObserver-triggered state and DOM writes into a coalesced, teardown-safe animation-frame commit
- enforce fixed-row visual containment in list and table layouts
- release `@askrjs/ui@0.0.32`

## TDD evidence

- Red `12873b635ec27bc5118029114676516c36a43bb5`: all three engines reported a 200px `VirtualList.scrollHeight` for 10,000 × 20px rows, browser-level ResizeObserver loop errors during resize churn, visible overflow in both row families, and a 96,024px table scroll state after replacement with a 408px-maximum dataset.
- Red guard extension `a333f95018463b3acf008860138b685096d0c0b2`: the same deferred-write/data-replacement bug was reproduced in `VirtualList` at 80,000px against a new 300px maximum.
- Green `3c466f9f93e001247914d422e31497247058ad43`: 45 focused behavior tests pass across Chromium, Firefox, and WebKit, followed by all 57 virtualization behavior, accessibility, and determinism tests across those engines.
- Full local gate at release head `75ca9a728bae57500c7e6e49678fb16ac790a079`: build, lint, types, unit/check/jsdom suites, 309 browser files / 1,296 browser tests, publint, and isolated packed-consumer validation all pass.
- All four benchmark tiers pass, including the `VirtualList` and `VirtualTable` hot paths; `npm audit --omit=dev` reports 0 vulnerabilities.

## Root causes and permanent guardrails

- `VirtualList` rendered only the live window. Semantically valid before/after spacer nodes now reserve exactly `itemCount * rowHeight`, including `ul`/`ol` composition. Normal browser CI asserts the real 200,000px `scrollHeight`, sets a native 20,000px scroll offset, dispatches the browser scroll event, and requires visible index 1,000.
- Deferred scroll state was clamped only when no pending value existed. Both primitives now clamp the pending value whenever data changes and again immediately before committing it, while a real user scroll cancels the obsolete frame and becomes authoritative. Cross-engine regressions replace large datasets with unrelated small datasets before the frame lands and assert both immediate API state and final DOM state remain in range.
- ResizeObserver callbacks synchronously wrote scroll and reactive state back into the observed layout. Observer delivery now only schedules one frame; the frame performs measurement-dependent writes outside the delivery cycle and is cancelled on ref transfer or teardown. Both primitives cycle seven extreme heights while listening to the browser `error` channel and forwarded console errors for the exact ResizeObserver-loop class.
- Fixed-height rows allowed descendants to paint outside the geometry used by virtualization math. List rows clip directly. Table rows use collapsed zero-spacing geometry plus fixed, overflow-hidden cells whose content is isolated in a clipped positioned layer, so tall descendants cannot expand or bleed into the next logical row. Three-engine geometry tests assert configured row height and unchanged next-row position.

## Acceptance audit

- [x] Reporter ownership and all four issue contracts were read back from GitHub.
- [x] Browser regressions were committed red before implementation, including both deferred-write primitives.
- [x] The same focused regressions pass green across Chromium, Firefox, and WebKit.
- [x] Permanent native-scroll, deferred-data, browser-error, teardown, and visual-geometry guardrails cover the bug classes.
- [x] Full local release, package, benchmark, and production-audit gates pass at the exact release head.
- [x] Exact-head hosted CI succeeds on macOS, Windows, and Ubuntu.
- [x] Every linked issue acceptance checkbox is checked with evidence before ready-for-review and squash merge.
- [x] `v0.0.32` peels to the squash-merged main SHA, npm integrity is verified, and a clean consumer exercises the repaired virtualization surfaces with a zero-vulnerability production audit.
