### PR TITLE
fix(overlay): mirror logical alignment and expose viewport bounds

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -59,6 +59,34 @@ These are documentation groupings only.
 - `VirtualTable` is a fixed-height table windowing primitive with a sticky
   head, stable keys, selection, and keyboard navigation.
 
+## Overlay positioning and sizing
+
+Anchored overlay families (`Popover`, `HoverCard`, `Tooltip`, `Dropdown`,
+`Menu`, and `Select`) interpret `align="start"` and `align="end"` as logical
+inline edges. The shared positioning engine reads the trigger's computed text
+direction, so those alignments mirror in right-to-left layouts when the overlay
+is above or below its trigger.
+
+Viewport collision handling chooses and clamps the overlay position. Because
+this package is headless, it does not shrink anchored content whose intrinsic
+size is larger than the viewport. The content exposes the current padded
+viewport bounds as `--ak-overlay-available-width` and
+`--ak-overlay-available-height`; apply them with an appropriate wrapping and
+overflow policy for application content:
+
+```css
+.app-overlay-content {
+  max-width: var(--ak-overlay-available-width);
+  max-height: var(--ak-overlay-available-height);
+  overflow: auto;
+  overflow-wrap: anywhere;
+}
+```
+
+Without that consumer rule, a long unbroken URL, hash, or identifier can remain
+wider than a narrow viewport. The engine still clamps its position, but position
+clamping alone cannot make oversized content fit.
+
 ## Keyboard interaction
 
 Keyboard behavior follows the semantic role of each public component and is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.0.88 <0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/_internal/overlay.ts
+++ b/src/components/_internal/overlay.ts
@@ -164,13 +164,14 @@ function resolveAlignedOffset(
   align: OverlayAlign,
   start: number,
   end: number,
-  size: number
+  size: number,
+  reverse: boolean = false
 ) {
   if (align === 'center') {
     return start + (end - start) / 2 - size / 2;
   }
 
-  if (align === 'end') {
+  if (align === (reverse ? 'start' : 'end')) {
     return end - size;
   }
 
@@ -189,6 +190,14 @@ function applyAnchoredPosition(
   const contentWidth = options.matchTriggerWidth
     ? Math.max(contentRect.width, triggerRect.width)
     : contentRect.width;
+  const availableWidth = Math.max(
+    0,
+    viewportWidth - options.viewportPadding * 2
+  );
+  const availableHeight = Math.max(
+    0,
+    viewportHeight - options.viewportPadding * 2
+  );
   const resolvedSide = resolveAnchoredSide(
     options.side,
     triggerRect,
@@ -207,7 +216,8 @@ function applyAnchoredPosition(
       options.align,
       triggerRect.left,
       triggerRect.right,
-      contentWidth
+      contentWidth,
+      window.getComputedStyle(trigger).direction === 'rtl'
     );
     top =
       resolvedSide === 'bottom'
@@ -241,6 +251,8 @@ function applyAnchoredPosition(
     position: 'fixed',
     inset: 'auto',
     margin: '0',
+    '--ak-overlay-available-width': `${Math.round(availableWidth)}px`,
+    '--ak-overlay-available-height': `${Math.round(availableHeight)}px`,
     left: `${Math.round(clamp(left, options.viewportPadding, maxLeft))}px`,
     top: `${Math.round(clamp(top, options.viewportPadding, maxTop))}px`,
     'min-width': options.matchTriggerWidth
@@ -281,6 +293,8 @@ function applyCenteredPosition(
     position: 'fixed',
     inset: 'auto',
     margin: '0',
+    '--ak-overlay-available-width': `${Math.round(maxWidth)}px`,
+    '--ak-overlay-available-height': `${Math.round(maxHeight)}px`,
     'max-width': `${Math.round(maxWidth)}px`,
     'max-height': `${Math.round(maxHeight)}px`,
     left: `${Math.round(

--- a/tests/browser/components/popover/behavior.test.tsx
+++ b/tests/browser/components/popover/behavior.test.tsx
@@ -231,6 +231,191 @@ describe('Popover - Behavior', () => {
     expect(getComputedStyle(content as Element).top).toBe('90px');
   });
 
+  it('should mirror start and end alignment for identical RTL trigger geometry', async () => {
+    container = mount(
+      <>
+        <div dir="ltr">
+          <Popover defaultOpen>
+            <PopoverTrigger
+              data-testid="ltr-start-trigger"
+              style={{
+                position: 'fixed',
+                left: '300px',
+                top: '80px',
+                boxSizing: 'border-box',
+                width: '80px',
+                height: '20px',
+              }}
+            >
+              LTR start
+            </PopoverTrigger>
+            <PopoverContent
+              data-testid="ltr-start"
+              align="start"
+              style={{
+                boxSizing: 'border-box',
+                width: '120px',
+                height: '30px',
+              }}
+            >
+              Details
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div dir="ltr">
+          <Popover defaultOpen>
+            <PopoverTrigger
+              data-testid="ltr-end-trigger"
+              style={{
+                position: 'fixed',
+                left: '300px',
+                top: '160px',
+                boxSizing: 'border-box',
+                width: '80px',
+                height: '20px',
+              }}
+            >
+              LTR end
+            </PopoverTrigger>
+            <PopoverContent
+              data-testid="ltr-end"
+              align="end"
+              style={{
+                boxSizing: 'border-box',
+                width: '120px',
+                height: '30px',
+              }}
+            >
+              Details
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div dir="rtl">
+          <Popover defaultOpen>
+            <PopoverTrigger
+              data-testid="rtl-start-trigger"
+              style={{
+                position: 'fixed',
+                left: '300px',
+                top: '240px',
+                boxSizing: 'border-box',
+                width: '80px',
+                height: '20px',
+              }}
+            >
+              RTL start
+            </PopoverTrigger>
+            <PopoverContent
+              data-testid="rtl-start"
+              align="start"
+              style={{
+                boxSizing: 'border-box',
+                width: '120px',
+                height: '30px',
+              }}
+            >
+              Details
+            </PopoverContent>
+          </Popover>
+        </div>
+        <div dir="rtl">
+          <Popover defaultOpen>
+            <PopoverTrigger
+              data-testid="rtl-end-trigger"
+              style={{
+                position: 'fixed',
+                left: '300px',
+                top: '320px',
+                boxSizing: 'border-box',
+                width: '80px',
+                height: '20px',
+              }}
+            >
+              RTL end
+            </PopoverTrigger>
+            <PopoverContent
+              data-testid="rtl-end"
+              align="end"
+              style={{
+                boxSizing: 'border-box',
+                width: '120px',
+                height: '30px',
+              }}
+            >
+              Details
+            </PopoverContent>
+          </Popover>
+        </div>
+      </>
+    );
+
+    await flushUpdates();
+    await flushUpdates();
+
+    const ltrStart = (
+      document.body.querySelector('[data-testid="ltr-start"]') as HTMLElement
+    ).getBoundingClientRect();
+    const ltrEnd = (
+      document.body.querySelector('[data-testid="ltr-end"]') as HTMLElement
+    ).getBoundingClientRect();
+    const rtlStart = (
+      document.body.querySelector('[data-testid="rtl-start"]') as HTMLElement
+    ).getBoundingClientRect();
+    const rtlEnd = (
+      document.body.querySelector('[data-testid="rtl-end"]') as HTMLElement
+    ).getBoundingClientRect();
+    const ltrTrigger = (
+      container.querySelector(
+        '[data-testid="ltr-start-trigger"]'
+      ) as HTMLElement
+    ).getBoundingClientRect();
+    const rtlTrigger = (
+      container.querySelector(
+        '[data-testid="rtl-start-trigger"]'
+      ) as HTMLElement
+    ).getBoundingClientRect();
+
+    expect(rtlTrigger.left).toBeCloseTo(ltrTrigger.left, 0);
+    expect(rtlTrigger.right).toBeCloseTo(ltrTrigger.right, 0);
+    expect(rtlTrigger.width).toBeCloseTo(ltrTrigger.width, 0);
+    expect(ltrStart.left).toBeCloseTo(rtlEnd.left, 0);
+    expect(ltrEnd.left).toBeCloseTo(rtlStart.left, 0);
+    expect(ltrStart.left).toBeGreaterThan(ltrEnd.left);
+  });
+
+  it('should expose the position-only clamp boundary for oversized content', async () => {
+    container = mount(
+      <div style={{ position: 'fixed', left: '120px', top: '80px' }}>
+        <Popover defaultOpen>
+          <PopoverTrigger>Open oversized popover</PopoverTrigger>
+          <PopoverContent
+            data-testid="oversized-content"
+            style={{ whiteSpace: 'nowrap' }}
+          >
+            {'W'.repeat(400)}
+          </PopoverContent>
+        </Popover>
+      </div>
+    );
+
+    await flushUpdates();
+    await flushUpdates();
+
+    const content = document.body.querySelector(
+      '[data-testid="oversized-content"]'
+    ) as HTMLElement;
+    const rect = content.getBoundingClientRect();
+
+    expect(rect.width).toBeGreaterThan(window.innerWidth);
+    expect(rect.left).toBeGreaterThanOrEqual(12);
+    expect(rect.right).toBeGreaterThan(window.innerWidth);
+    expect(
+      getComputedStyle(content)
+        .getPropertyValue('--ak-overlay-available-width')
+        .trim()
+    ).toBe(`${window.innerWidth - 24}px`);
+  });
+
   it('should close nested popover without closing parent dialog on Escape', async () => {
     container = mount(
       <Dialog defaultOpen>


### PR DESCRIPTION
Closes #59.
Closes #60.

## Summary

- resolve start/end as logical inline alignment from the trigger computed direction
- expose padded viewport width and height through stable overlay CSS custom properties
- document the headless position-only clamp boundary and a consumer sizing/wrapping recipe
- release @askrjs/ui@0.0.33

## TDD evidence

- Red 3f9dba4d84626b6be5931785069ed6ce465494a1: real-browser regressions failed in Chromium, Firefox, and WebKit because RTL start/end stayed at the LTR physical positions and oversized content exposed no available-width hook.
- Green b72500f0492f57ef17ec59d86b6befa48b1c2a3d: the same 27 focused Popover behavior tests pass in all three engines after the shared positioning fix.
- Exact release head 14251849d86592ca27a0d631327ead498b500553: the full npm run check gate passes unit, check, jsdom, three-engine browser, build, lint, types, publint, pack, and installed-package checks; all four benchmark tiers and npm audit --omit=dev pass.

## Root causes and permanent guardrails

- The shared alignment helper interpreted start/end as physical coordinates. The implementation now reads the trigger computed direction for the horizontal cross axis. A standing real-layout regression fixes identical trigger geometry across LTR and RTL and cross-compares start/end positions in every supported browser engine.
- Position clamping cannot make intrinsically oversized headless content fit. The shared engine now exposes --ak-overlay-available-width and --ak-overlay-available-height, while the real-browser adversarial test preserves the documented position-only boundary using 400 unbroken characters in a narrow viewport. The docs give consumers an explicit max-size, overflow, and wrapping recipe.

## Acceptance audit

- [x] Reporter ownership and both issue contracts were read back from GitHub.
- [x] Focused real-browser regressions were committed red before implementation and pass green.
- [x] Permanent RTL and adversarial oversized-content guardrails cover the bug classes in all three engines.
- [x] Headless sizing responsibility, logical alignment, and the supported reactive sizing hooks are documented.
- [x] Full local release, package, benchmark, and production-audit gates pass at the exact release head.
- [x] Exact-head hosted CI succeeds.
- [x] Every linked issue acceptance checkbox is checked with evidence before ready-for-review and squash merge.
- [x] v0.0.33 peels to the squash-merged main SHA, npm integrity is verified, and a clean consumer exercises the repaired overlay surface with a zero-vulnerability production audit.