### PR TITLE
Isolate component instances and finite progress values

### DIFF
--- a/src/components/_internal/progress.ts
+++ b/src/components/_internal/progress.ts
@@ -1,5 +1,5 @@
 export function normalizeProgressMax(max: number | undefined) {
-  if (typeof max !== 'number' || Number.isNaN(max) || max <= 0) {
+  if (typeof max !== 'number' || !Number.isFinite(max) || max <= 0) {
     return 100;
   }
 

--- a/src/components/dismissable-layer/dismissable-layer.tsx
+++ b/src/components/dismissable-layer/dismissable-layer.tsx
@@ -1,6 +1,6 @@
 import { Slot, createLayer } from '@askrjs/askr/foundations/structures';
 import { composeRefs, mergeProps } from '@askrjs/askr/foundations/utilities';
-import { getSignal } from '@askrjs/askr';
+import { getSignal, state } from '@askrjs/askr';
 import { resolveCompoundId } from '../_internal/id';
 import type {
   DismissableLayerAsChildProps,
@@ -27,10 +27,10 @@ type LayerEntry = {
 };
 
 const layerManager = createLayer();
-const layerEntries = new Map<string, LayerEntry>();
+const layerEntries = new Map<object, LayerEntry>();
 
-function getLayerEntry(layerId: string): LayerEntry {
-  const existing = layerEntries.get(layerId);
+function getLayerEntry(identity: object): LayerEntry {
+  const existing = layerEntries.get(identity);
 
   if (existing) {
     return existing;
@@ -45,7 +45,7 @@ function getLayerEntry(layerId: string): LayerEntry {
         return;
       }
 
-      unregisterLayer(layerId);
+      unregisterLayer(created);
 
       if (!node) {
         return;
@@ -97,7 +97,7 @@ function getLayerEntry(layerId: string): LayerEntry {
 
       created.lastEscapeEvent = event;
       event.stopPropagation?.();
-      runDismissCallbacks(layerId, 'escape');
+      runDismissCallbacks(created, 'escape');
     },
     handlePointerDownCapture: (event: PointerEvent) => {
       if (created.disabled) {
@@ -113,7 +113,7 @@ function getLayerEntry(layerId: string): LayerEntry {
       }
 
       created.lastOutsidePointerEvent = event;
-      runDismissCallbacks(layerId, 'outside');
+      runDismissCallbacks(created, 'outside');
     },
     lastEscapeEvent: null,
     lastOutsidePointerEvent: null,
@@ -123,11 +123,11 @@ function getLayerEntry(layerId: string): LayerEntry {
     cleanupSignal: null,
   };
 
-  layerEntries.set(layerId, created);
+  layerEntries.set(identity, created);
   return created;
 }
 
-function registerLayerCleanup(layerId: string, entry: LayerEntry) {
+function registerLayerCleanup(identity: object, entry: LayerEntry) {
   const signal = getSignal();
   if (entry.cleanupSignal === signal) {
     return;
@@ -139,8 +139,8 @@ function registerLayerCleanup(layerId: string, entry: LayerEntry) {
       if (entry.cleanupSignal !== signal) {
         return;
       }
-      unregisterLayer(layerId);
-      layerEntries.delete(layerId);
+      unregisterLayer(entry);
+      layerEntries.delete(identity);
     },
     { once: true }
   );
@@ -153,10 +153,8 @@ export function dismissableLayerEntryCountForTests(): number {
   return layerEntries.size;
 }
 
-function unregisterLayer(layerId: string) {
-  const entry = layerEntries.get(layerId);
-
-  if (!entry?.unregister) {
+function unregisterLayer(entry: LayerEntry) {
+  if (!entry.unregister) {
     return;
   }
 
@@ -168,10 +166,8 @@ function unregisterLayer(layerId: string) {
   entry.node = null;
 }
 
-function runDismissCallbacks(layerId: string, trigger: 'escape' | 'outside') {
-  const entry = layerEntries.get(layerId);
-
-  if (!entry || entry.disabled || !entry.isTop?.()) {
+function runDismissCallbacks(entry: LayerEntry, trigger: 'escape' | 'outside') {
+  if (entry.disabled || !entry.isTop?.()) {
     return;
   }
 
@@ -241,9 +237,11 @@ export function DismissableLayer(
     ...rest
   } = props;
 
-  const layerId = resolveCompoundId('dismissable-layer', id, children);
-  const entry = getLayerEntry(layerId);
-  registerLayerCleanup(layerId, entry);
+  const identity = state<object>({
+    id: resolveCompoundId('dismissable-layer', id, children),
+  })();
+  const entry = getLayerEntry(identity);
+  registerLayerCleanup(identity, entry);
   entry.disabled = disabled;
   entry.disableOutsidePointerEvents = disableOutsidePointerEvents;
   entry.onEscapeKeyDown = onEscapeKeyDown;

--- a/tests/browser/components/dismissable-layer/behavior.test.tsx
+++ b/tests/browser/components/dismissable-layer/behavior.test.tsx
@@ -137,4 +137,31 @@ describe('DismissableLayer - Behavior', () => {
 
     expect(dismissableLayerEntryCountForTests()).toBe(baseline);
   });
+
+  it('should isolate layers with the same explicit ID across mount roots', () => {
+    const firstDismiss = vi.fn();
+    const secondDismiss = vi.fn();
+    const firstContainer = mount(
+      <DismissableLayer id="shared" onDismiss={firstDismiss}>
+        <div>First</div>
+      </DismissableLayer>
+    );
+    const secondContainer = mount(
+      <DismissableLayer id="shared" onDismiss={secondDismiss}>
+        <div>Second</div>
+      </DismissableLayer>
+    );
+
+    try {
+      unmount(secondContainer);
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'Escape' })
+      );
+
+      expect(firstDismiss).toHaveBeenCalledOnce();
+      expect(secondDismiss).not.toHaveBeenCalled();
+    } finally {
+      unmount(firstContainer);
+    }
+  });
 });

--- a/tests/browser/components/progress/behavior.test.tsx
+++ b/tests/browser/components/progress/behavior.test.tsx
@@ -52,4 +52,22 @@ describe('Progress - Behavior', () => {
       unmount(container);
     }
   });
+
+  it.each([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY, Number.NaN])(
+    'should normalize non-finite max %s to the default ARIA maximum',
+    (max) => {
+      const container = mount(<Progress value={40} max={max} />);
+
+      try {
+        const root = container.querySelector(
+          `[role="${PROGRESS_A11Y_CONTRACT.ROLE}"]`
+        );
+        expect(
+          root?.getAttribute(PROGRESS_A11Y_CONTRACT.VALUE_MAX_ATTRIBUTE)
+        ).toBe('100');
+      } finally {
+        unmount(container);
+      }
+    }
+  );
 });


### PR DESCRIPTION
## Summary
- key dismissable-layer registry state by component identity instead of caller-supplied IDs
- preserve surviving layers when a same-ID sibling root unmounts
- normalize all non-finite progress maxima to the documented default
- add real-browser regression coverage

## Validation
- npm run check

Closes #68
Closes #69