### PR TITLE
ci: use readable action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: npm
-
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: ci
-    uses: askrjs/actions/.github/workflows/publish-package.yml@1ecd3e84c32b3ff9bb85111baabbd31f79c459dd
+    uses: askrjs/actions/.github/workflows/publish-package.yml@main
     with:
       install-playwright: true
     permissions:


### PR DESCRIPTION
## Summary

- use readable action refs in CI and publication
- inherit the shared publisher environment through askrjs/actions#15
- keep every workflow step explicitly named with consistent whitespace

## Validation

- `actionlint .github/workflows/*.yml`
- `npm run fmt -- --check`, `npm run lint`, `npm run typecheck`, `npm test`, `npm run build`, `npm run test:publint`, `npm run pack:check`
- zero SHA-pinned action refs and zero unnamed workflow steps