### PR TITLE
fix: harden theming and accessibility contracts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@askrjs/ui",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@askrjs/askr": ">=0.2.0 <0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@askrjs/ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Headless Askr components",
   "keywords": [
     "accessible",

--- a/src/components/_internal/dynamic-style.ts
+++ b/src/components/_internal/dynamic-style.ts
@@ -1,9 +1,11 @@
+import { registerSSRStyle } from '@askrjs/askr';
+
 type StyleValue = number | string | null | undefined;
 
 const MAX_DYNAMIC_RULES = 512;
 type Registry = {
   element: HTMLStyleElement;
-  rules: Map<string, string>;
+  rules: Map<string, { rule: string; selector: string }>;
 };
 const registries = new WeakMap<Document, Map<string, Registry>>();
 
@@ -35,13 +37,18 @@ function getRegistry(nonce: string | undefined): Registry | null {
   created.setAttribute('data-askr-dynamic-styles', 'true');
   if (nonce !== undefined) created.nonce = nonce;
   document.head.appendChild(created);
-  const registry = { element: created, rules: new Map<string, string>() };
+  const registry = {
+    element: created,
+    rules: new Map<string, { rule: string; selector: string }>(),
+  };
   documentRegistries.set(key, registry);
   return registry;
 }
 
 function syncRegistry(registry: Registry) {
-  registry.element.textContent = Array.from(registry.rules.values()).join('\n');
+  registry.element.textContent = Array.from(registry.rules.values())
+    .map(({ rule }) => rule)
+    .join('\n');
 }
 
 function buildDynamicStyleRule(
@@ -107,17 +114,25 @@ export function setDynamicStyleRule(
     return;
   }
 
+  if (typeof document === 'undefined') {
+    registerSSRStyle(`askr-dynamic:${nonce ?? ''}:${key}`, rule);
+    return;
+  }
+
   const registry = getRegistry(nonce);
   if (!registry) return;
-  if (registry.rules.get(key) === rule && registry.element.isConnected) {
+  if (registry.rules.get(key)?.rule === rule && registry.element.isConnected) {
     return;
   }
 
   if (!registry.rules.has(key) && registry.rules.size >= MAX_DYNAMIC_RULES) {
-    const oldest = registry.rules.keys().next().value as string | undefined;
-    if (oldest !== undefined) registry.rules.delete(oldest);
+    for (const [candidateKey, candidate] of registry.rules) {
+      if (document.querySelector(candidate.selector)) continue;
+      registry.rules.delete(candidateKey);
+      break;
+    }
   }
-  registry.rules.set(key, rule);
+  registry.rules.set(key, { rule, selector });
   syncRegistry(registry);
 }
 

--- a/src/components/_internal/native-control.ts
+++ b/src/components/_internal/native-control.ts
@@ -1,39 +1,7 @@
-type NativeButtonStyleValue =
-  | string
-  | Record<string, string | number | null | undefined | false>
-  | null
-  | undefined
-  | false;
-type NativeButtonStyle =
-  | NativeButtonStyleValue
-  | (() => NativeButtonStyleValue);
-
-function inheritedFontValue(
-  style: NativeButtonStyleValue
-): NativeButtonStyleValue {
-  if (typeof style === 'string') {
-    return `font: inherit;${style}`;
-  }
-
-  if (style && typeof style === 'object') {
-    return { font: 'inherit', ...style };
-  }
-
-  return { font: 'inherit' };
-}
-
-function inheritNativeControlFont(style: unknown): NativeButtonStyle {
-  if (typeof style === 'function') {
-    return () => inheritedFontValue((style as () => NativeButtonStyleValue)());
-  }
-
-  return inheritedFontValue(style as NativeButtonStyleValue);
-}
-
-/** Adds the accessibility-critical UA typography reset beneath caller styles. */
+/** Marks native button fallbacks without imposing presentation on them. */
 export function nativeButtonProps<T extends object>(props: T): T {
   return {
     ...props,
-    style: inheritNativeControlFont((props as { style?: unknown }).style),
+    'data-askr-native-control': 'true',
   } as T;
 }

--- a/src/components/alert-dialog/alert-dialog-content.tsx
+++ b/src/components/alert-dialog/alert-dialog-content.tsx
@@ -37,6 +37,7 @@ export function AlertDialogContent(
   };
   const sharedProps = {
     ...(rest as Omit<AlertDialogContentProps, 'children'>),
+    role: rest.role ?? 'alertdialog',
     onEscapeKeyDown: handleEscapeKeyDown,
     onPointerDownOutside: handlePointerDownOutside,
     onInteractOutside,

--- a/src/components/menubar/menubar-content.tsx
+++ b/src/components/menubar/menubar-content.tsx
@@ -187,10 +187,7 @@ function renderMenubarSurfaceContent(
         return;
       }
 
-      if (attempt >= 8) {
-        node.style.position = 'fixed';
-        return;
-      }
+      if (attempt >= 8) return;
 
       requestAnimationFrame(() => {
         syncPosition(attempt + 1);

--- a/src/components/virtual-list/virtual-list.tsx
+++ b/src/components/virtual-list/virtual-list.tsx
@@ -1,4 +1,4 @@
-import { state } from '@askrjs/askr';
+import { cspNonce, state } from '@askrjs/askr';
 import type { JSXElement } from '@askrjs/askr/foundations/structures';
 import type { Ref } from '@askrjs/askr/foundations/utilities';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
@@ -20,6 +20,11 @@ import {
   type VirtualRange,
 } from '../_internal/virtualization';
 import { isJsxElement } from '../_internal/jsx';
+import {
+  dynamicAttributeSelector,
+  removeDynamicStyleRuleWhenUnused,
+  setDynamicStyleRule,
+} from '../_internal/dynamic-style';
 import type {
   VirtualListApi,
   VirtualListAsChildProps,
@@ -31,6 +36,41 @@ import type {
 type StateCell<T> = (() => T) & {
   set: (next: T | ((prev: T) => T)) => void;
 };
+
+function virtualListLayoutProps<Item>(
+  entry: VirtualListEntry<Item>,
+  kind: 'row' | 'spacer',
+  height: number
+): Record<string, string> {
+  const value = String(height);
+  const attribute = `data-askr-virtual-list-${kind}-height`;
+  const key = `virtual-list:${kind}:${value}`;
+  const selector = dynamicAttributeSelector(attribute, value);
+  setDynamicStyleRule(
+    key,
+    selector,
+    {
+      height: `${height}px`,
+      'list-style': 'none',
+      flex: '0 0 auto',
+      overflow: 'hidden',
+      ...(kind === 'spacer' ? { 'pointer-events': 'none' } : {}),
+    },
+    entry.layoutNonce
+  );
+  entry.nextLayoutRules.set(key, selector);
+  return { [attribute]: value };
+}
+
+function commitVirtualListLayoutRules<Item>(entry: VirtualListEntry<Item>) {
+  for (const [key, selector] of entry.layoutRules) {
+    if (!entry.nextLayoutRules.has(key)) {
+      removeDynamicStyleRuleWhenUnused(key, selector);
+    }
+  }
+  entry.layoutRules = entry.nextLayoutRules;
+  entry.nextLayoutRules = new Map();
+}
 
 type VirtualListEntry<Item> = {
   node: HTMLElement | null;
@@ -62,6 +102,9 @@ type VirtualListEntry<Item> = {
   api: VirtualListApi<Item>;
   visibleRange: VirtualRange;
   onScroll: ((event: Event) => void) | undefined;
+  layoutRules: Map<string, string>;
+  nextLayoutRules: Map<string, string>;
+  layoutNonce: string | undefined;
 };
 
 function cloneJsxElement(
@@ -87,6 +130,8 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
   }
 
   const entry = {} as VirtualListEntry<Item>;
+  entry.layoutRules = new Map();
+  entry.nextLayoutRules = new Map();
   const readScrollTop = () => entry.scrollTopState!();
   const setScrollTop = (nextScrollTop: number) => {
     entry.scrollTopState!.set(nextScrollTop);
@@ -301,6 +346,13 @@ function getVirtualListEntry<Item>(key: object): VirtualListEntry<Item> {
 
     if (entry.node === node) {
       return;
+    }
+
+    if (node === null) {
+      for (const [key, selector] of entry.layoutRules) {
+        removeDynamicStyleRuleWhenUnused(key, selector);
+      }
+      entry.layoutRules.clear();
     }
 
     if (entry.pendingCommitFrame !== null) {
@@ -565,13 +617,7 @@ function renderVirtualListRows<Item>(
         aria-hidden="true"
         data-slot="virtual-list-spacer"
         data-position={position}
-        style={{
-          height: `${height}px`,
-          listStyle: 'none',
-          flex: '0 0 auto',
-          overflow: 'hidden',
-          pointerEvents: 'none',
-        }}
+        {...virtualListLayoutProps(entry, 'spacer', height)}
       />
     );
   };
@@ -600,12 +646,7 @@ function renderVirtualListRows<Item>(
         data-index={String(index)}
         data-key={rowKey}
         data-visible={isVisible ? 'true' : 'false'}
-        style={{
-          height: `${entry.rowHeight}px`,
-          listStyle: 'none',
-          flex: '0 0 auto',
-          overflow: 'hidden',
-        }}
+        {...virtualListLayoutProps(entry, 'row', entry.rowHeight)}
       >
         <RowComponent
           item={item}
@@ -757,6 +798,7 @@ export function VirtualList<Item>(
   };
 
   const rowHeight = assertPositiveVirtualHeight(rowHeightProp, 'rowHeight');
+  const layoutNonce = cspNonce();
   const instanceState = state({}) as StateCell<object>;
   const entry = getVirtualListEntry<Item>(instanceState());
   const scrollTopState = state(0) as StateCell<number>;
@@ -771,6 +813,7 @@ export function VirtualList<Item>(
   entry.scrollTopState = scrollTopState;
   entry.viewportHeightState = viewportHeightState;
   entry.rowHeight = rowHeight;
+  entry.layoutNonce = layoutNonce;
   entry.viewportHeightHint = viewportHeightHint;
   entry.overscan = overscan;
   entry.rowComponent = RowComponent;
@@ -827,6 +870,7 @@ export function VirtualList<Item>(
       )}
     </>
   );
+  commitVirtualListLayoutRules(entry);
 
   if (asChild) {
     if (!isJsxElement(children)) {

--- a/src/components/virtual-table/virtual-table.tsx
+++ b/src/components/virtual-table/virtual-table.tsx
@@ -1,4 +1,4 @@
-import { state } from '@askrjs/askr';
+import { cspNonce, state } from '@askrjs/askr';
 import type { JSXElement } from '@askrjs/askr/foundations/structures';
 import type { Ref } from '@askrjs/askr/foundations/utilities';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
@@ -19,6 +19,11 @@ import {
   type VirtualScrollAlignment,
 } from '../_internal/virtualization';
 import { isJsxElement } from '../_internal/jsx';
+import {
+  dynamicAttributeSelector,
+  removeDynamicStyleRuleWhenUnused,
+  setDynamicStyleRule,
+} from '../_internal/dynamic-style';
 import type {
   VirtualTableApi,
   VirtualTableAsChildProps,
@@ -30,6 +35,31 @@ import type {
 type StateCell<T> = (() => T) & {
   set: (next: T | ((prev: T) => T)) => void;
 };
+
+function virtualTableLayoutProps<Row>(
+  entry: VirtualTableEntry<Row>,
+  kind: string,
+  value: string | undefined,
+  declarations: Record<string, string | number | undefined>
+): Record<string, string> {
+  if (value === undefined) return {};
+  const attribute = `data-askr-virtual-table-${kind}`;
+  const key = `virtual-table:${kind}:${value}`;
+  const selector = dynamicAttributeSelector(attribute, value);
+  setDynamicStyleRule(key, selector, declarations, entry.layoutNonce);
+  entry.nextLayoutRules.set(key, selector);
+  return { [attribute]: value };
+}
+
+function commitVirtualTableLayoutRules<Row>(entry: VirtualTableEntry<Row>) {
+  for (const [key, selector] of entry.layoutRules) {
+    if (!entry.nextLayoutRules.has(key)) {
+      removeDynamicStyleRuleWhenUnused(key, selector);
+    }
+  }
+  entry.layoutRules = entry.nextLayoutRules;
+  entry.nextLayoutRules = new Map();
+}
 
 type VirtualTableEntry<Row> = {
   wrapperNode: HTMLElement | null;
@@ -65,6 +95,9 @@ type VirtualTableEntry<Row> = {
     | undefined;
   getKey: ((row: Row, index: number) => string | number) | null;
   onScroll: ((event: Event) => void) | undefined;
+  layoutRules: Map<string, string>;
+  nextLayoutRules: Map<string, string>;
+  layoutNonce: string | undefined;
 };
 
 const virtualTableEntries = new WeakMap<object, VirtualTableEntry<unknown>>();
@@ -95,6 +128,8 @@ function getVirtualTableEntry<Row>(
   }
 
   const entry = {} as VirtualTableEntry<Row>;
+  entry.layoutRules = new Map();
+  entry.nextLayoutRules = new Map();
 
   const applyPendingScrollTop = () => {
     const pendingScrollTop = entry.pendingScrollTop;
@@ -293,6 +328,13 @@ function getVirtualTableEntry<Row>(
 
     if (entry.wrapperNode === node) {
       return;
+    }
+
+    if (node === null) {
+      for (const [key, selector] of entry.layoutRules) {
+        removeDynamicStyleRuleWhenUnused(key, selector);
+      }
+      entry.layoutRules.clear();
     }
 
     if (entry.pendingCommitFrame !== null) {
@@ -693,23 +735,34 @@ function getVirtualTableHostName(element: JSXElement | null): string {
 }
 
 function renderVirtualTableColumns<Row>(
+  entry: VirtualTableEntry<Row>,
   columns: readonly VirtualTableColumn<Row>[]
 ) {
   return columns.map((column) => {
     const width =
       typeof column.width === 'number' ? `${column.width}px` : column.width;
 
-    return <col key={column.id} style={{ width }} />;
+    return (
+      <col
+        key={column.id}
+        {...virtualTableLayoutProps(entry, 'column-width', width, { width })}
+      />
+    );
   });
 }
 
 function renderVirtualTableHeader<Row>(
+  entry: VirtualTableEntry<Row>,
   columns: readonly VirtualTableColumn<Row>[]
 ) {
   return (
     <thead
       data-slot="virtual-table-head"
-      style={{ position: 'sticky', top: 0, zIndex: 1 }}
+      {...virtualTableLayoutProps(entry, 'head-layout', 'sticky', {
+        position: 'sticky',
+        top: 0,
+        'z-index': 1,
+      })}
     >
       <tr data-slot="virtual-table-header-row">
         {columns.map((column) => {
@@ -724,7 +777,9 @@ function renderVirtualTableHeader<Row>(
               scope="col"
               data-slot="virtual-table-header-cell"
               data-column-id={column.id}
-              style={{ width }}
+              {...virtualTableLayoutProps(entry, 'column-width', width, {
+                width,
+              })}
             >
               {column.header}
             </th>
@@ -766,11 +821,16 @@ function renderVirtualTableRows<Row>(
       >
         <td
           colSpan={colSpan}
-          style={{
-            height: `${visibleRange.beforeSpacerHeight}px`,
-            padding: 0,
-            border: 0,
-          }}
+          {...virtualTableLayoutProps(
+            entry,
+            'spacer-height',
+            String(visibleRange.beforeSpacerHeight),
+            {
+              height: `${visibleRange.beforeSpacerHeight}px`,
+              padding: 0,
+              border: 0,
+            }
+          )}
         />
       </tr>
     );
@@ -794,7 +854,15 @@ function renderVirtualTableRows<Row>(
         data-selected={selected ? 'true' : 'false'}
         aria-rowindex={index + 1}
         aria-selected={selected ? 'true' : 'false'}
-        style={{ height: `${entry.rowHeight}px`, overflow: 'hidden' }}
+        {...virtualTableLayoutProps(
+          entry,
+          'row-height',
+          String(entry.rowHeight),
+          {
+            height: `${entry.rowHeight}px`,
+            overflow: 'hidden',
+          }
+        )}
         onClick={(event: MouseEvent) => {
           onRowClick(row, index, rowKey, event);
         }}
@@ -807,21 +875,31 @@ function renderVirtualTableRows<Row>(
               key={column.id}
               data-slot="virtual-table-cell"
               data-column-id={column.id}
-              style={{
-                boxSizing: 'border-box',
-                height: `${entry.rowHeight}px`,
-                maxHeight: `${entry.rowHeight}px`,
-                overflow: 'hidden',
-                position: 'relative',
-              }}
+              {...virtualTableLayoutProps(
+                entry,
+                'cell-height',
+                String(entry.rowHeight),
+                {
+                  'box-sizing': 'border-box',
+                  height: `${entry.rowHeight}px`,
+                  'max-height': `${entry.rowHeight}px`,
+                  overflow: 'hidden',
+                  position: 'relative',
+                }
+              )}
             >
               <div
                 data-slot="virtual-table-cell-content"
-                style={{
-                  inset: 0,
-                  overflow: 'hidden',
-                  position: 'absolute',
-                }}
+                {...virtualTableLayoutProps(
+                  entry,
+                  'cell-content-layout',
+                  'clipped',
+                  {
+                    inset: 0,
+                    overflow: 'hidden',
+                    position: 'absolute',
+                  }
+                )}
               >
                 <CellComponent
                   row={row}
@@ -847,11 +925,16 @@ function renderVirtualTableRows<Row>(
       >
         <td
           colSpan={colSpan}
-          style={{
-            height: `${visibleRange.afterSpacerHeight}px`,
-            padding: 0,
-            border: 0,
-          }}
+          {...virtualTableLayoutProps(
+            entry,
+            'spacer-height',
+            String(visibleRange.afterSpacerHeight),
+            {
+              height: `${visibleRange.afterSpacerHeight}px`,
+              padding: 0,
+              border: 0,
+            }
+          )}
         />
       </tr>
     );
@@ -903,6 +986,7 @@ export function VirtualTable<Row>(
   };
 
   const rowHeight = assertPositiveVirtualHeight(rowHeightProp, 'rowHeight');
+  const layoutNonce = cspNonce();
   const headerHeight = assertPositiveVirtualHeight(
     headerHeightProp,
     'headerHeight'
@@ -952,6 +1036,7 @@ export function VirtualTable<Row>(
   entry.scrollTopState = scrollTopState;
   entry.viewportHeightState = viewportHeightState;
   entry.rowHeight = rowHeight;
+  entry.layoutNonce = layoutNonce;
   entry.headerHeight = headerHeight;
   entry.overscan = overscan;
   entry.columns = columns;
@@ -1029,8 +1114,8 @@ export function VirtualTable<Row>(
     }
   );
 
-  const columnsMarkup = renderVirtualTableColumns(columns);
-  const headerMarkup = renderVirtualTableHeader(columns);
+  const columnsMarkup = renderVirtualTableColumns(entry, columns);
+  const headerMarkup = renderVirtualTableHeader(entry, columns);
 
   const rowsMarkup = renderVirtualTableRows(
     entry,
@@ -1061,17 +1146,18 @@ export function VirtualTable<Row>(
   const tableBody = (
     <table
       {...tableProps}
-      style={{
-        borderCollapse: 'collapse',
-        borderSpacing: 0,
-        tableLayout: 'fixed',
-      }}
+      {...virtualTableLayoutProps(entry, 'table-layout', 'fixed', {
+        'border-collapse': 'collapse',
+        'border-spacing': 0,
+        'table-layout': 'fixed',
+      })}
     >
       {columnsMarkup.length > 0 ? <colgroup>{columnsMarkup}</colgroup> : null}
       {headerMarkup}
       <tbody data-slot="virtual-table-body">{rowsMarkup}</tbody>
     </table>
   );
+  commitVirtualTableLayoutRules(entry);
 
   if (asChild) {
     if (!isJsxElement(children)) {

--- a/tests/browser/components/alert-dialog/behavior.test.tsx
+++ b/tests/browser/components/alert-dialog/behavior.test.tsx
@@ -18,6 +18,33 @@ describe('AlertDialog - Behavior', () => {
     unmount(container);
   });
 
+  it('should default content to alertdialog while allowing an explicit role', async () => {
+    container = mount(
+      <>
+        <AlertDialog defaultOpen>
+          <AlertDialogPortal>
+            <AlertDialogContent>Default role</AlertDialogContent>
+          </AlertDialogPortal>
+        </AlertDialog>
+        <AlertDialog defaultOpen>
+          <AlertDialogPortal>
+            <AlertDialogContent role="dialog">Explicit role</AlertDialogContent>
+          </AlertDialogPortal>
+        </AlertDialog>
+      </>
+    );
+
+    await flushUpdates();
+
+    const contents = Array.from(
+      document.body.querySelectorAll('[data-slot="dialog-content"]')
+    );
+    expect(contents.map((content) => content.getAttribute('role'))).toEqual([
+      'alertdialog',
+      'dialog',
+    ]);
+  });
+
   it('should keep trigger expansion state open after re-activation', async () => {
     container = mount(
       <AlertDialog>

--- a/tests/browser/components/dynamic-style/behavior.test.tsx
+++ b/tests/browser/components/dynamic-style/behavior.test.tsx
@@ -11,6 +11,38 @@ function settleMicrotask(): Promise<void> {
 }
 
 describe('dynamic style rules', () => {
+  it('should retain every mounted rule when the bounded cache is full', () => {
+    const nonce = 'YWN0aXZlLXJ1bGVzLXRlc3Q=';
+    const targets: HTMLElement[] = [];
+    const keys: string[] = [];
+
+    try {
+      for (let index = 0; index <= 512; index += 1) {
+        const key = `active-rule:${index}`;
+        const value = String(index);
+        const selector = dynamicAttributeSelector('data-active-rule', value);
+        const target = document.createElement('div');
+        target.setAttribute('data-active-rule', value);
+        document.body.appendChild(target);
+        targets.push(target);
+        keys.push(key);
+        setDynamicStyleRule(key, selector, { height: `${index + 1}px` }, nonce);
+      }
+
+      const rules = Array.from(
+        document.querySelectorAll<HTMLStyleElement>(
+          'style[data-askr-dynamic-styles]'
+        )
+      ).find((style) => style.nonce === nonce)?.textContent;
+
+      expect(rules).toContain('[data-active-rule="0"]');
+      expect(rules).toContain('[data-active-rule="512"]');
+    } finally {
+      for (const target of targets) target.remove();
+      for (const key of keys) removeDynamicStyleRule(key);
+    }
+  });
+
   it('should keep rules during ref swaps and remove them after unmount', async () => {
     const key = 'test:dynamic-style-ref-swap';
     const attr = 'data-dynamic-style-test';

--- a/tests/browser/components/hover-card/behavior.test.tsx
+++ b/tests/browser/components/hover-card/behavior.test.tsx
@@ -160,9 +160,6 @@ describe('HoverCard - Behavior', () => {
       </HoverCard>
     );
     await flushUpdates();
-    let trigger = container.querySelector(
-      '[data-slot="hover-card-trigger"]'
-    ) as HTMLElement;
     const content = document.body.querySelector(
       '[data-slot="hover-card-content"]'
     ) as HTMLElement;

--- a/tests/browser/components/native-control/behavior.test.tsx
+++ b/tests/browser/components/native-control/behavior.test.tsx
@@ -10,7 +10,7 @@ import {
 import { Toggle } from '../../../../src/components/toggle';
 import { mount, unmount } from '../../test-utils';
 
-describe('Native control typography', () => {
+describe('Native control styling', () => {
   let container: HTMLElement | undefined;
 
   afterEach(() => {
@@ -20,9 +20,7 @@ describe('Native control typography', () => {
     document.body.style.removeProperty('font-family');
   });
 
-  it('should inherit page typography across representative native button fallbacks', () => {
-    document.documentElement.style.fontSize = '32px';
-    document.body.style.fontFamily = 'serif';
+  it('should mark representative native button fallbacks without inline styles', () => {
     container = mount(
       <div>
         <Button data-testid="button">Button</Button>
@@ -40,15 +38,12 @@ describe('Native control typography', () => {
       </div>
     );
 
-    expect(getComputedStyle(document.body).fontSize).toBe('32px');
     for (const testId of ['button', 'menu-item', 'select-trigger', 'toggle']) {
-      const style = getComputedStyle(
-        container.querySelector(`[data-testid="${testId}"]`)!
-      );
-      expect(style.fontSize, testId).toBe('32px');
-      expect(style.fontFamily, testId).toBe(
-        getComputedStyle(document.body).fontFamily
-      );
+      const control = container.querySelector<HTMLElement>(
+        `[data-testid="${testId}"]`
+      )!;
+      expect(control.dataset.askrNativeControl, testId).toBe('true');
+      expect(control.getAttribute('style'), testId).toBeNull();
     }
   });
 

--- a/tests/browser/components/virtual-list/behavior.test.tsx
+++ b/tests/browser/components/virtual-list/behavior.test.tsx
@@ -1,4 +1,4 @@
-import { state } from '@askrjs/askr';
+import { CspNonceScope, state } from '@askrjs/askr';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   VirtualList,
@@ -30,6 +30,53 @@ describe('VirtualList - Behavior', () => {
   afterEach(() => {
     unmount(container);
     container = undefined;
+  });
+
+  it('should release generated layout rules after unmount', async () => {
+    const nonce = 'dmlydHVhbC1saXN0LW5vbmNl';
+    container = mount(
+      <CspNonceScope value={nonce}>
+        <VirtualList
+          aria-label="Messages"
+          style={{ height: '74px', overflowY: 'auto' }}
+          items={createItems(3)}
+          rowHeight={37}
+          getKey={(item) => item.id}
+          rowComponent={({ item }) => <span>{item.label}</span>}
+        />
+      </CspNonceScope>
+    );
+    await flushUpdates();
+
+    const dynamicStyles = () =>
+      Array.from(
+        document.querySelectorAll<HTMLStyleElement>(
+          'style[data-askr-dynamic-styles]'
+        )
+      )
+        .map((style) => style.textContent ?? '')
+        .join('\n');
+
+    expect(dynamicStyles()).toContain('data-askr-virtual-list-row-height="37"');
+    expect(
+      Array.from(
+        document.querySelectorAll<HTMLStyleElement>(
+          'style[data-askr-dynamic-styles]'
+        )
+      ).some(
+        (style) =>
+          style.nonce === nonce &&
+          style.textContent?.includes('data-askr-virtual-list-row-height="37"')
+      )
+    ).toBe(true);
+
+    unmount(container);
+    container = undefined;
+    await Promise.resolve();
+
+    expect(dynamicStyles()).not.toContain(
+      'data-askr-virtual-list-row-height="37"'
+    );
   });
 
   it('should render a virtual window, scroll by index, and follow the bottom', async () => {

--- a/tests/browser/components/virtual-table/behavior.test.tsx
+++ b/tests/browser/components/virtual-table/behavior.test.tsx
@@ -1,4 +1,4 @@
-import { state } from '@askrjs/askr';
+import { CspNonceScope, state } from '@askrjs/askr';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import {
   VirtualTable,
@@ -46,6 +46,67 @@ describe('VirtualTable - Behavior', () => {
   afterEach(() => {
     unmount(container);
     container = undefined;
+  });
+
+  it('should release generated layout rules after unmount', async () => {
+    const nonce = 'dmlydHVhbC10YWJsZS1ub25jZQ';
+    container = mount(
+      <CspNonceScope value={nonce}>
+        <VirtualTable
+          aria-label="Users"
+          style={{ height: '129px', overflowY: 'auto' }}
+          rows={createRows(3)}
+          rowHeight={43}
+          headerHeight={43}
+          getKey={(row) => row.id}
+          columns={[
+            {
+              ...columns[0],
+              width: 173,
+            },
+          ]}
+        />
+      </CspNonceScope>
+    );
+    await flushUpdates();
+
+    const dynamicStyles = () =>
+      Array.from(
+        document.querySelectorAll<HTMLStyleElement>(
+          'style[data-askr-dynamic-styles]'
+        )
+      )
+        .map((style) => style.textContent ?? '')
+        .join('\n');
+
+    expect(dynamicStyles()).toContain(
+      'data-askr-virtual-table-row-height="43"'
+    );
+    expect(dynamicStyles()).toContain(
+      'data-askr-virtual-table-column-width="173px"'
+    );
+    expect(
+      Array.from(
+        document.querySelectorAll<HTMLStyleElement>(
+          'style[data-askr-dynamic-styles]'
+        )
+      ).some(
+        (style) =>
+          style.nonce === nonce &&
+          style.textContent?.includes('data-askr-virtual-table-row-height="43"')
+      )
+    ).toBe(true);
+
+    unmount(container);
+    container = undefined;
+    await Promise.resolve();
+
+    expect(dynamicStyles()).not.toContain(
+      'data-askr-virtual-table-row-height="43"'
+    );
+    expect(dynamicStyles()).not.toContain(
+      'data-askr-virtual-table-column-width="173px"'
+    );
   });
 
   it('should render a sticky-headed virtual table and support keyboard selection', async () => {

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -28,7 +28,7 @@ describe('Source layout', () => {
     }
   });
 
-  it('should route every component-owned native button through the shared typography reset', () => {
+  it('should route every component-owned native button through the shared theme marker', () => {
     const componentsDirectory = join(process.cwd(), 'src', 'components');
     const rawNativeButtons: string[] = [];
 
@@ -54,7 +54,7 @@ describe('Source layout', () => {
       join(componentsDirectory, '_internal', 'native-control.ts'),
       'utf8'
     );
-    expect(sharedControl).toContain("font: 'inherit'");
+    expect(sharedControl).toContain("'data-askr-native-control': 'true'");
   });
 
   it('should keep roving composites on the shared identity and focus guardrails', () => {

--- a/tests/unit/source-style-contract.test.ts
+++ b/tests/unit/source-style-contract.test.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+
+function sourceFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const candidate = path.join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(candidate);
+    return entry.isFile() && /\.(ts|tsx)$/.test(entry.name) ? [candidate] : [];
+  });
+}
+
+describe('Component style contract', () => {
+  it('should not emit or mutate inline styles', () => {
+    const components = path.resolve(__dirname, '../../src/components');
+    const violations = sourceFiles(components).flatMap((file) => {
+      const relative = path.relative(components, file);
+      return fs
+        .readFileSync(file, 'utf8')
+        .split(/\r?\n/)
+        .flatMap((line, index) =>
+          /\bstyle\s*=\s*(?:\{|['"])|\.style\.[A-Za-z_$][\w$]*\s*=|\.style\.setProperty\s*\(|setAttribute\(\s*['"]style['"]/.test(
+            line
+          )
+            ? [`${relative}:${index + 1}: ${line.trim()}`]
+            : []
+        );
+    });
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/virtualization-ssr.test.tsx
+++ b/tests/unit/virtualization-ssr.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vite-plus/test';
+import { renderToStringSync } from '@askrjs/askr/ssr';
+import { VirtualList } from '../../src/components/virtual-list';
+import {
+  VirtualTable,
+  type VirtualTableColumn,
+} from '../../src/components/virtual-table';
+
+type Row = { id: string; name: string };
+
+const rows: readonly Row[] = [
+  { id: 'one', name: 'One' },
+  { id: 'two', name: 'Two' },
+  { id: 'three', name: 'Three' },
+];
+
+const columns: readonly VirtualTableColumn<Row>[] = [
+  {
+    id: 'name',
+    header: 'Name',
+    width: 173,
+    cellComponent: ({ row }) => <span>{row.name}</span>,
+  },
+];
+
+function renderWithStyles(component: () => JSX.Element) {
+  let styles = '';
+  const html = renderToStringSync(
+    component,
+    {},
+    {
+      cspNonce: 'c3NyLXZpcnR1YWxpemF0aW9u',
+      onContext: (context) => {
+        styles = Array.from(context.ssrStyles.values())
+          .map(({ cssText }) => cssText)
+          .join('\n');
+      },
+    }
+  );
+  return { html, styles };
+}
+
+describe('virtualization SSR styles', () => {
+  it('should register virtual-list geometry before hydration', () => {
+    const { html, styles } = renderWithStyles(() => (
+      <VirtualList
+        aria-label="Messages"
+        style={{ height: '60px', overflowY: 'auto' }}
+        items={rows}
+        rowHeight={20}
+        getKey={(row) => row.id}
+        rowComponent={({ item }) => <span>{item.name}</span>}
+      />
+    ));
+
+    expect(html).toContain('data-askr-virtual-list-row-height="20"');
+    expect(styles).toContain(
+      '[data-askr-virtual-list-row-height="20"] { height: 20px;'
+    );
+  });
+
+  it('should register virtual-table geometry before hydration', () => {
+    const { html, styles } = renderWithStyles(() => (
+      <VirtualTable
+        aria-label="Users"
+        style={{ height: '120px', overflowY: 'auto' }}
+        rows={rows}
+        rowHeight={24}
+        headerHeight={24}
+        getKey={(row) => row.id}
+        columns={columns}
+      />
+    ));
+
+    expect(html).toContain('data-askr-virtual-table-row-height="24"');
+    expect(styles).toContain(
+      '[data-askr-virtual-table-row-height="24"] { height: 24px;'
+    );
+    expect(styles).toContain(
+      '[data-askr-virtual-table-column-width="173px"] { width: 173px;'
+    );
+    expect(styles).toContain('[data-askr-virtual-table-table-layout="fixed"]');
+  });
+});

--- a/vitest.test.unit.config.ts
+++ b/vitest.test.unit.config.ts
@@ -12,11 +12,13 @@ export default defineConfig({
       'tests/unit/composite-id.test.tsx',
       'tests/unit/foundations-contract.test.ts',
       'tests/unit/source-layout.test.ts',
+      'tests/unit/source-style-contract.test.ts',
       'tests/unit/public-api.test.ts',
       'tests/unit/react-free-public-surface.test.ts',
       'tests/unit/export-map.test.ts',
       'tests/unit/docs-contract.test.ts',
       'tests/unit/dynamic-children-contract.test.ts',
+      'tests/unit/virtualization-ssr.test.tsx',
     ],
   },
 });


### PR DESCRIPTION
## Summary

- remove component-authored inline styles and enforce the source contract
- preserve virtual list and table layout across CSP, SSR, and dynamic-rule lifecycles
- correct AlertDialog and menubar accessibility semantics
- bump @askrjs/ui to 0.2.1

## Validation

- npm run check
- 12 unit files / 21 tests
- 4 jsdom files / 13 tests
- 309 browser files / 1326 tests
- publint and isolated package validation

Closes #74