### PR TITLE
Fix virtual-table production polish and dialog contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,22 @@ npm install @askrjs/themes
 Import the root package when you want the full composition surface:
 
 ```tsx
-import { Button, Dialog, DialogTrigger, DialogContent } from '@askrjs/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTrigger,
+} from '@askrjs/ui';
+
+<Dialog>
+  <DialogTrigger>Open dialog</DialogTrigger>
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogContent>Confirm action</DialogContent>
+  </DialogPortal>
+</Dialog>;
 ```
 
 Use per-component subpaths when you want smaller bundles or direct entrypoints:

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,22 @@ npm install @askrjs/ui @askrjs/askr
 ```
 
 ```tsx
-import { Button, Dialog, DialogContent, DialogTrigger } from '@askrjs/ui';
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogTrigger,
+} from '@askrjs/ui';
+
+<Dialog>
+  <DialogTrigger>Open dialog</DialogTrigger>
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogContent>Confirm action</DialogContent>
+  </DialogPortal>
+</Dialog>;
 ```
 
 For larger surfaces, use grouped imports from the root package and direct

--- a/docs/components.md
+++ b/docs/components.md
@@ -42,7 +42,11 @@ These are documentation groupings only.
 
 - AlertDialog is a Dialog specialization for blocking confirmations. Its action
   and cancel parts intentionally alias the same close behavior for
-  compatibility.
+  compatibility. Always render `AlertDialogOverlay` alongside
+  `AlertDialogContent` inside the portal.
+- `DialogOverlay` and `AlertDialogOverlay` are fully styled out of the box when
+  used with `@askrjs/themes/default`: the theme supplies the backdrop token,
+  blur, stacking, and fade animation. Standard usage needs no additional CSS.
 - Toast is a stacked notification family. `ToastHost` owns the registry,
   `ToastViewport` renders the stack, and `Toast` registers entries rather than
   rendering standalone DOM.
@@ -150,8 +154,12 @@ import { VirtualTable as VirtualTableSubpath } from '@askrjs/ui/virtual-table';
 ```
 
 `VirtualList` keeps list rendering headless while the caller supplies the row
-component. `VirtualTable` keeps the semantic table structure intact while the
-caller supplies column metadata and cell renderers.
+component. `VirtualTable` renders native table elements with interactive grid
+semantics while the caller supplies column metadata and cell renderers. Give a
+virtual table an accessible name and a bounded viewport. Keyboard row selection
+is handled only while the grid itself has focus; links, buttons, and form
+controls rendered inside cells retain their native click, focus, and keyboard
+behavior.
 
 ## See also
 

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -38,6 +38,29 @@ import {
 </Dialog>;
 ```
 
+The same portal structure applies to `AlertDialog`; use
+`AlertDialogOverlay` next to `AlertDialogContent`. With
+`@askrjs/themes/default`, both overlay variants already include the backdrop,
+blur, stacking, and animation treatment.
+
+#### Backdrop customization
+
+Customize the shared theme contract rather than passing a competing class to
+the overlay:
+
+```css
+/* Correct: all Dialog and AlertDialog overlays stay consistent. */
+:root {
+  --ak-color-backdrop: rgb(8 12 20 / 18%);
+  --ak-z-modal-backdrop: 1040;
+}
+```
+
+```tsx
+// Incorrect: bypasses the shipped backdrop, blur, and stacking treatment.
+<AlertDialogOverlay className="opaque-dialog-overlay" />
+```
+
 ### Form control pattern
 
 ```tsx
@@ -87,13 +110,20 @@ const columns = [
 />
 
 <VirtualTable
+  aria-label="People"
   rows={[{ id: '1', name: 'Ada' }]}
   rowHeight={32}
   headerHeight={32}
   getKey={(row) => row.id}
   columns={columns}
+  viewport="lg"
 />
 ```
+
+`VirtualTable` needs an accessible name and a bounded viewport so its grid and
+windowing contracts remain meaningful. Its row-navigation keys operate when the
+grid itself is focused; interactive controls rendered by a cell component keep
+their native behavior.
 
 Use the direct subpaths when you want a narrower family import surface; use
 the root export when you are already importing other askr-ui primitives in the

--- a/src/components/alert-dialog/alert-dialog.tsx
+++ b/src/components/alert-dialog/alert-dialog.tsx
@@ -15,6 +15,7 @@
  * <AlertDialog>
  *   <AlertDialogTrigger>Delete item</AlertDialogTrigger>
  *   <AlertDialogPortal>
+ *     <AlertDialogOverlay />
  *     <AlertDialogContent>
  *       <AlertDialogTitle>Delete item?</AlertDialogTitle>
  *       <AlertDialogDescription>

--- a/src/components/dialog/dialog-overlay.tsx
+++ b/src/components/dialog/dialog-overlay.tsx
@@ -9,6 +9,11 @@ import type {
 /**
  * Renders the `dialog-overlay` part of `dialog`.
  *
+ * With `@askrjs/themes/default`, the overlay is fully styled out of the box
+ * with the shared backdrop token, blur, stacking, and fade animation. Standard
+ * Dialog and AlertDialog usage requires no additional overlay CSS; customize
+ * the theme tokens instead of applying a competing background class.
+ *
  * Supports polymorphic rendering via `asChild`.
  */
 export function DialogOverlay(props: DialogOverlayProps): JSX.Element | null;

--- a/src/components/dialog/dialog-root.tsx
+++ b/src/components/dialog/dialog-root.tsx
@@ -44,7 +44,18 @@ function syncDialogLabelAttributes(
 }
 
 /**
- * Renders a part of `dialog`.
+ * Coordinates the Dialog trigger, portal, overlay, and content.
+ *
+ * @example
+ * ```tsx
+ * <Dialog>
+ *   <DialogTrigger>Open dialog</DialogTrigger>
+ *   <DialogPortal>
+ *     <DialogOverlay />
+ *     <DialogContent>Confirm action</DialogContent>
+ *   </DialogPortal>
+ * </Dialog>
+ * ```
  */
 export function Dialog(props: DialogProps) {
   const {

--- a/src/components/virtual-table/virtual-table.tsx
+++ b/src/components/virtual-table/virtual-table.tsx
@@ -36,6 +36,81 @@ type StateCell<T> = (() => T) & {
   set: (next: T | ((prev: T) => T)) => void;
 };
 
+const VIRTUAL_TABLE_INTERACTIVE_TARGET_SELECTOR = [
+  'a[href]',
+  'area[href]',
+  'audio[controls]',
+  'button',
+  'embed',
+  'iframe',
+  'input',
+  'label',
+  'object',
+  'select',
+  'summary',
+  'textarea',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  '[tabindex]',
+  '[role="button"]',
+  '[role="checkbox"]',
+  '[role="combobox"]',
+  '[role="grid"]',
+  '[role="gridcell"]',
+  '[role="link"]',
+  '[role="listbox"]',
+  '[role="menu"]',
+  '[role="menuitem"]',
+  '[role="menuitemcheckbox"]',
+  '[role="menuitemradio"]',
+  '[role="option"]',
+  '[role="radio"]',
+  '[role="scrollbar"]',
+  '[role="searchbox"]',
+  '[role="slider"]',
+  '[role="spinbutton"]',
+  '[role="switch"]',
+  '[role="tab"]',
+  '[role="textbox"]',
+  '[role="tree"]',
+  '[role="treegrid"]',
+  '[role="treeitem"]',
+].join(',');
+
+function isVirtualTableInteractiveEventTarget(
+  event: Event,
+  boundary: Element | null
+): boolean {
+  if (!boundary) {
+    return false;
+  }
+
+  const eventPath = event.composedPath();
+  const boundaryIndex = eventPath.indexOf(boundary);
+
+  if (boundaryIndex >= 0) {
+    return eventPath
+      .slice(0, boundaryIndex)
+      .some(
+        (target) =>
+          target instanceof Element &&
+          target.matches(VIRTUAL_TABLE_INTERACTIVE_TARGET_SELECTOR)
+      );
+  }
+
+  const target = event.target;
+  const interactiveTarget =
+    target instanceof Element
+      ? target.closest(VIRTUAL_TABLE_INTERACTIVE_TARGET_SELECTOR)
+      : null;
+
+  return Boolean(
+    interactiveTarget &&
+    interactiveTarget !== boundary &&
+    boundary.contains(interactiveTarget)
+  );
+}
+
 function virtualTableLayoutProps<Row>(
   entry: VirtualTableEntry<Row>,
   kind: string,
@@ -269,6 +344,13 @@ function getVirtualTableEntry<Row>(
   };
 
   const handleKeyDown = (event: KeyboardEvent) => {
+    if (
+      event.defaultPrevented ||
+      isVirtualTableInteractiveEventTarget(event, entry.tableNode)
+    ) {
+      return;
+    }
+
     if (event.altKey || event.ctrlKey || event.metaKey) {
       return;
     }
@@ -755,6 +837,19 @@ function renderVirtualTableHeader<Row>(
   entry: VirtualTableEntry<Row>,
   columns: readonly VirtualTableColumn<Row>[]
 ) {
+  const headerHeight = String(entry.headerHeight);
+  const headerHeightProps = virtualTableLayoutProps(
+    entry,
+    'header-height',
+    headerHeight,
+    {
+      'box-sizing': 'border-box',
+      height: `${entry.headerHeight}px`,
+      'max-height': `${entry.headerHeight}px`,
+      overflow: 'hidden',
+    }
+  );
+
   return (
     <thead
       data-slot="virtual-table-head"
@@ -764,7 +859,11 @@ function renderVirtualTableHeader<Row>(
         'z-index': 1,
       })}
     >
-      <tr data-slot="virtual-table-header-row">
+      <tr
+        aria-rowindex={1}
+        data-slot="virtual-table-header-row"
+        {...headerHeightProps}
+      >
         {columns.map((column) => {
           const width =
             typeof column.width === 'number'
@@ -777,6 +876,7 @@ function renderVirtualTableHeader<Row>(
               scope="col"
               data-slot="virtual-table-header-cell"
               data-column-id={column.id}
+              {...headerHeightProps}
               {...virtualTableLayoutProps(entry, 'column-width', width, {
                 width,
               })}
@@ -851,8 +951,9 @@ function renderVirtualTableRows<Row>(
         data-slot="virtual-table-row"
         data-row-index={String(index)}
         data-row-key={rowKey}
+        data-terminal-row={index === rows.length - 1 ? 'true' : undefined}
         data-selected={selected ? 'true' : 'false'}
-        aria-rowindex={index + 1}
+        aria-rowindex={index + 2}
         aria-selected={selected ? 'true' : 'false'}
         {...virtualTableLayoutProps(
           entry,
@@ -864,6 +965,16 @@ function renderVirtualTableRows<Row>(
           }
         )}
         onClick={(event: MouseEvent) => {
+          const rowNode =
+            event.currentTarget instanceof Element ? event.currentTarget : null;
+
+          if (
+            event.defaultPrevented ||
+            isVirtualTableInteractiveEventTarget(event, rowNode)
+          ) {
+            return;
+          }
+
           onRowClick(row, index, rowKey, event);
         }}
       >
@@ -1084,15 +1195,25 @@ export function VirtualTable<Row>(
     'data-virtual-table': 'true',
     'data-viewport': viewport,
     'data-table-width': tableWidth,
+    'data-at-top': effectiveScrollTop <= 0 ? 'true' : 'false',
+    'data-at-bottom': stateSnapshot.isAtBottom ? 'true' : 'false',
+    'data-empty': stateSnapshot.count === 0 ? 'true' : 'false',
   });
 
   const tableProps = mergeProps(
     {
+      ref: entry.tableRef,
+      'data-slot': 'virtual-table-table',
+      'data-virtual-table-table': 'true',
+      role: 'grid',
+      'aria-rowcount': String(stateSnapshot.count + 1),
+      'aria-colcount': String(columns.length),
+      onKeyDown: entry.handleKeyDown,
+    },
+    {
       'aria-label': ariaLabel,
       'aria-labelledby': ariaLabelledBy,
       'aria-describedby': ariaDescribedBy,
-      'aria-rowcount': String(stateSnapshot.count),
-      'aria-colcount': String(columns.length),
       tabIndex: (tabIndex ?? 0) as JSX.IntrinsicElements['table']['tabIndex'],
       ...(onKeyDown
         ? {
@@ -1105,12 +1226,6 @@ export function VirtualTable<Row>(
       ...(onBlur
         ? { onBlur: onBlur as JSX.IntrinsicElements['table']['onBlur'] }
         : {}),
-    },
-    {
-      ref: entry.tableRef,
-      'data-slot': 'virtual-table-table',
-      'data-virtual-table-table': 'true',
-      onKeyDown: entry.handleKeyDown,
     }
   );
 

--- a/tests/browser/components/virtual-table/a11y.test.tsx
+++ b/tests/browser/components/virtual-table/a11y.test.tsx
@@ -28,7 +28,7 @@ const columns = [
 ] as const;
 
 describe('VirtualTable - Accessibility', () => {
-  it('should have no automated axe violations for a semantic virtual table', async () => {
+  it('should have no automated axe violations for a selectable virtual grid', async () => {
     await expectNoAxeViolations(
       <VirtualTable
         aria-label="Users"

--- a/tests/browser/components/virtual-table/behavior.test.tsx
+++ b/tests/browser/components/virtual-table/behavior.test.tsx
@@ -83,8 +83,16 @@ describe('VirtualTable - Behavior', () => {
       'data-askr-virtual-table-row-height="43"'
     );
     expect(dynamicStyles()).toContain(
+      'data-askr-virtual-table-header-height="43"'
+    );
+    expect(dynamicStyles()).toContain(
       'data-askr-virtual-table-column-width="173px"'
     );
+    expect(
+      container
+        .querySelector('[data-slot="virtual-table-header-cell"]')
+        ?.getBoundingClientRect().height
+    ).toBe(43);
     expect(
       Array.from(
         document.querySelectorAll<HTMLStyleElement>(
@@ -103,6 +111,9 @@ describe('VirtualTable - Behavior', () => {
 
     expect(dynamicStyles()).not.toContain(
       'data-askr-virtual-table-row-height="43"'
+    );
+    expect(dynamicStyles()).not.toContain(
+      'data-askr-virtual-table-header-height="43"'
     );
     expect(dynamicStyles()).not.toContain(
       'data-askr-virtual-table-column-width="173px"'
@@ -134,15 +145,43 @@ describe('VirtualTable - Behavior', () => {
     const table = container.querySelector(
       '[data-slot="virtual-table-table"]'
     ) as HTMLTableElement | null;
+    const root = container.querySelector(
+      '[data-slot="virtual-table"]'
+    ) as HTMLElement | null;
     const firstRow = container.querySelector(
       '[data-row-key="row-0"]'
     ) as HTMLTableRowElement | null;
 
-    expect(table?.getAttribute('aria-rowcount')).toBe('10');
+    expect(table?.getAttribute('role')).toBe('grid');
+    expect(table?.getAttribute('aria-rowcount')).toBe('11');
+    expect(
+      container
+        .querySelector('[data-slot="virtual-table-header-row"]')
+        ?.getAttribute('aria-rowindex')
+    ).toBe('1');
     expect(
       container.querySelectorAll('[data-slot="virtual-table-row"]')
     ).toHaveLength(4);
+    const mountedRows = Array.from(
+      container.querySelectorAll('[data-slot="virtual-table-row"]')
+    );
+    expect(mountedRows.at(-1)?.getAttribute('data-terminal-row')).toBeNull();
     expect(firstRow?.getAttribute('aria-selected')).toBe('false');
+    expect(firstRow?.getAttribute('aria-rowindex')).toBe('2');
+    expect(root?.getAttribute('data-at-top')).toBe('true');
+    expect(root?.getAttribute('data-at-bottom')).toBe('false');
+    expect(root?.getAttribute('data-empty')).toBe('false');
+
+    if (root) {
+      root.scrollTop = 1;
+      root.dispatchEvent(new Event('scroll'));
+      await flushUpdates();
+      expect(root.getAttribute('data-at-top')).toBe('false');
+
+      root.scrollTop = 0;
+      root.dispatchEvent(new Event('scroll'));
+      await flushUpdates();
+    }
 
     firstRow?.click();
     await flushUpdates();
@@ -167,7 +206,159 @@ describe('VirtualTable - Behavior', () => {
     await flushUpdates();
 
     expect(api?.isAtBottom()).toBe(true);
-    expect(container.querySelector('[data-row-key="row-9"]')).toBeTruthy();
+    expect(container.querySelector('[data-row-key="row-9"]')).toHaveAttribute(
+      'data-terminal-row',
+      'true'
+    );
+    expect(root?.getAttribute('data-at-bottom')).toBe('true');
+  });
+
+  it('should preserve nested interactive cell behavior without selecting its row', async () => {
+    let api: VirtualTableApi<Row> | null = null;
+    const onCellAction = vi.fn();
+
+    container = mount(
+      <VirtualTable
+        aria-label="Users"
+        style={{ height: '120px', overflowY: 'auto' }}
+        rows={createRows(4)}
+        rowHeight={40}
+        headerHeight={40}
+        getKey={(row) => row.id}
+        columns={[
+          ...columns,
+          {
+            id: 'actions',
+            header: 'Actions',
+            cellComponent: ({ row }) => (
+              <button type="button" onClick={() => onCellAction(row.id)}>
+                Open {row.id}
+              </button>
+            ),
+          },
+        ]}
+        apiRef={(next) => {
+          api = next;
+        }}
+      />
+    );
+    await flushUpdates();
+
+    const action = container.querySelector(
+      '[data-row-key="row-0"] button'
+    ) as HTMLButtonElement;
+    action.focus();
+    action.click();
+    await flushUpdates();
+
+    expect(onCellAction).toHaveBeenCalledWith('row-0');
+    expect(api?.getSelectedRowKey()).toBeNull();
+    expect(document.activeElement).toBe(action);
+
+    action.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true })
+    );
+    await flushUpdates();
+
+    expect(api?.getSelectedRowKey()).toBeNull();
+    expect(document.activeElement).toBe(action);
+  });
+
+  it('should honor default-prevented nested events before selecting a row', async () => {
+    let api: VirtualTableApi<Row> | null = null;
+
+    container = mount(
+      <VirtualTable
+        aria-label="Users"
+        style={{ height: '120px', overflowY: 'auto' }}
+        rows={createRows(4)}
+        rowHeight={40}
+        headerHeight={40}
+        getKey={(row) => row.id}
+        columns={[
+          {
+            id: 'name',
+            header: 'Name',
+            cellComponent: ({ row }) => (
+              <span
+                data-prevent-table-event="true"
+                onClick={(event: MouseEvent) => event.preventDefault()}
+                onKeyDown={(event: KeyboardEvent) => event.preventDefault()}
+              >
+                {row.name}
+              </span>
+            ),
+          },
+        ]}
+        apiRef={(next) => {
+          api = next;
+        }}
+      />
+    );
+    await flushUpdates();
+
+    const target = container.querySelector(
+      '[data-row-key="row-0"] [data-prevent-table-event]'
+    ) as HTMLElement;
+    const clickEvent = new MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(clickEvent);
+    await flushUpdates();
+
+    expect(clickEvent.defaultPrevented).toBe(true);
+    expect(api?.getSelectedRowKey()).toBeNull();
+
+    const keyEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    });
+    target.dispatchEvent(keyEvent);
+    await flushUpdates();
+
+    expect(keyEvent.defaultPrevented).toBe(true);
+    expect(api?.getSelectedRowKey()).toBeNull();
+  });
+
+  it('should let a caller prevent the table keyboard behavior', async () => {
+    let api: VirtualTableApi<Row> | null = null;
+    const onKeyDown = vi.fn((event: KeyboardEvent) => {
+      event.preventDefault();
+    });
+
+    container = mount(
+      <VirtualTable
+        aria-label="Users"
+        style={{ height: '120px', overflowY: 'auto' }}
+        rows={createRows(4)}
+        rowHeight={40}
+        headerHeight={40}
+        getKey={(row) => row.id}
+        columns={columns}
+        onKeyDown={onKeyDown}
+        apiRef={(next) => {
+          api = next;
+        }}
+      />
+    );
+    await flushUpdates();
+
+    const table = container.querySelector(
+      '[data-slot="virtual-table-table"]'
+    ) as HTMLTableElement;
+    const keyEvent = new KeyboardEvent('keydown', {
+      key: 'ArrowDown',
+      bubbles: true,
+      cancelable: true,
+    });
+    table.dispatchEvent(keyEvent);
+    await flushUpdates();
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(keyEvent.defaultPrevented).toBe(true);
+    expect(api?.getSelectedRowKey()).toBeNull();
   });
 
   it('should map typed viewport and table width affordances to stable data attributes', async () => {
@@ -190,6 +381,27 @@ describe('VirtualTable - Behavior', () => {
 
     expect(table?.getAttribute('data-viewport')).toBe('lg');
     expect(table?.getAttribute('data-table-width')).toBe('compact');
+  });
+
+  it('should expose the empty scroll-edge state to themes', async () => {
+    container = mount(
+      <VirtualTable
+        aria-label="Users"
+        style={{ height: '120px', overflowY: 'auto' }}
+        rows={[]}
+        rowHeight={24}
+        headerHeight={24}
+        getKey={(row: Row) => row.id}
+        columns={columns}
+      />
+    );
+    await flushUpdates();
+
+    const root = container.querySelector('[data-slot="virtual-table"]');
+
+    expect(root?.getAttribute('data-at-top')).toBe('true');
+    expect(root?.getAttribute('data-at-bottom')).toBe('true');
+    expect(root?.getAttribute('data-empty')).toBe('true');
   });
 
   it('should support asChild composition on the wrapper host', async () => {

--- a/tests/unit/docs-contract.test.ts
+++ b/tests/unit/docs-contract.test.ts
@@ -41,6 +41,36 @@ function extractDocumentedImports(docs: string) {
 }
 
 describe('Docs contract', () => {
+  it('should document the shipped dialog overlay in canonical examples and customization guidance', () => {
+    const read = (filename: string) =>
+      readFileSync(join(process.cwd(), filename), 'utf8');
+    const rootReadme = read('README.md');
+    const docsReadme = read('docs/README.md');
+    const components = read('docs/components.md');
+    const composition = read('docs/composition.md');
+    const dialogSource = read('src/components/dialog/dialog-root.tsx');
+    const alertDialogSource = read(
+      'src/components/alert-dialog/alert-dialog.tsx'
+    );
+    const overlaySource = read('src/components/dialog/dialog-overlay.tsx');
+
+    for (const canonicalExample of [
+      rootReadme,
+      docsReadme,
+      composition,
+      dialogSource,
+    ]) {
+      expect(canonicalExample).toContain('<DialogOverlay />');
+    }
+
+    expect(alertDialogSource).toContain('<AlertDialogOverlay />');
+    expect(components).toContain('fully styled out of the box');
+    expect(overlaySource).toContain('requires no additional overlay CSS');
+    expect(composition).toContain('--ak-color-backdrop');
+    expect(composition).toContain('--ak-z-modal-backdrop');
+    expect(composition).toContain('Incorrect:');
+  });
+
   it('should only references import paths that are published by package exports', () => {
     const packageJson = JSON.parse(
       readFileSync(join(process.cwd(), 'package.json'), 'utf8')

--- a/tests/unit/virtualization-ssr.test.tsx
+++ b/tests/unit/virtualization-ssr.test.tsx
@@ -73,8 +73,13 @@ describe('virtualization SSR styles', () => {
     ));
 
     expect(html).toContain('data-askr-virtual-table-row-height="24"');
+    expect(html).toContain('data-askr-virtual-table-header-height="24"');
+    expect(html).toContain('data-row-key="three" data-terminal-row="true"');
     expect(styles).toContain(
       '[data-askr-virtual-table-row-height="24"] { height: 24px;'
+    );
+    expect(styles).toContain(
+      '[data-askr-virtual-table-header-height="24"] { box-sizing: border-box; height: 24px; max-height: 24px; overflow: hidden;'
     );
     expect(styles).toContain(
       '[data-askr-virtual-table-column-width="173px"] { width: 173px;'


### PR DESCRIPTION
## Summary

- harden VirtualTable sizing, scrolling, accessibility, and terminal-row semantics
- expose an explicit terminal-row attribute so themes preserve dividers on nonterminal virtual windows
- complete Dialog and AlertDialog overlay contracts and documentation
- add focused browser, SSR, accessibility, and docs-contract regressions

## Related issues

- Related to askrjs/askr-themes#95
- Supplies the terminal-row contract consumed by the companion themes PR

## Validation

- `npm run check`
- 309 browser test files / 1,338 browser tests passed
- unit, typecheck, build, and jsdom lanes passed
