### PR TITLE
feat(menu): support standalone structured navigation

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -122,6 +122,33 @@ HoverCard is a non-modal interactive preview. Pointer opening does not move
 focus. Tab can enter its content from the trigger, Escape restores the trigger,
 and leaving its final control continues after the trigger.
 
+### Standalone navigation menus
+
+`Menu` is also the supported accessible primitive for an always-visible list
+of navigation choices; it does not require a popover or trigger. Compose links
+through `MenuItem asChild` so native navigation is preserved while arrow keys,
+Home/End, and typeahead remain available without consumer event wiring.
+
+```tsx
+<Menu>
+  <MenuContent aria-label="Choose a workspace">
+    <MenuItem asChild textValue="Acme production">
+      <a href="/workspaces/acme">
+        <MenuItemIcon aria-hidden="true">
+          <BuildingIcon />
+        </MenuItemIcon>
+        <MenuItemLabel>Acme</MenuItemLabel>
+        <MenuItemDescription>Production workspace</MenuItemDescription>
+      </a>
+    </MenuItem>
+  </MenuContent>
+</Menu>
+```
+
+The default theme styles the content surface, item dividers, leading icon,
+primary label, description, and hover/focus states. Use `textValue` whenever
+structured children do not provide the intended typeahead phrase directly.
+
 ## Dynamic descendants
 
 Dynamic descendants are a supported composition contract for

--- a/src/components/menu/index.ts
+++ b/src/components/menu/index.ts
@@ -1,6 +1,11 @@
 export { Menu } from './menu-root';
 export { MenuContent } from './menu-content';
 export { MenuItem } from './menu-item';
+export {
+  MenuItemDescription,
+  MenuItemIcon,
+  MenuItemLabel,
+} from './menu-item-parts';
 export { MenuGroup, MenuLabel, MenuSeparator } from './menu-group';
 export { MENU_A11Y_CONTRACT, type MenuA11yContract } from './menu.a11y';
 export type {
@@ -11,6 +16,8 @@ export type {
   MenuItemOwnProps,
   MenuItemProps,
   MenuItemAsChildProps,
+  MenuItemPartProps,
+  MenuItemPartAsChildProps,
   MenuGroupProps,
   MenuGroupAsChildProps,
   MenuLabelProps,

--- a/src/components/menu/menu-content.tsx
+++ b/src/components/menu/menu-content.tsx
@@ -1,7 +1,9 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
-import { moveFocusOutsideCompositeWithTab } from '../_internal/focus';
-import { focusSelectedCollectionItem } from '../_internal/focus';
+import {
+  focusSelectedCollectionItem,
+  moveFocusOutsideCompositeWithTab,
+} from '../_internal/focus';
 import { getMenuCollection } from '../_internal/menu';
 import { readMenuRootContext } from './menu.shared';
 import type { MenuContentAsChildProps, MenuContentProps } from './menu.types';

--- a/src/components/menu/menu-content.tsx
+++ b/src/components/menu/menu-content.tsx
@@ -1,6 +1,8 @@
 import { Slot } from '@askrjs/askr/foundations/structures';
 import { mergeProps } from '@askrjs/askr/foundations/utilities';
 import { moveFocusOutsideCompositeWithTab } from '../_internal/focus';
+import { focusSelectedCollectionItem } from '../_internal/focus';
+import { getMenuCollection } from '../_internal/menu';
 import { readMenuRootContext } from './menu.shared';
 import type { MenuContentAsChildProps, MenuContentProps } from './menu.types';
 
@@ -24,6 +26,26 @@ export function MenuContent(props: MenuContentProps | MenuContentAsChildProps) {
     onKeyDown: (event: KeyboardEvent) => {
       if (root.handleTypeaheadKeyDown(event)) {
         return;
+      }
+
+      if (event.key === 'Home' || event.key === 'End') {
+        const enabledItems = root.resolvedState.items.filter(
+          (item) => !item.disabled
+        );
+        const item =
+          event.key === 'Home'
+            ? enabledItems[0]
+            : enabledItems[enabledItems.length - 1];
+
+        if (item) {
+          event.preventDefault();
+          root.setCurrentIndex(item.index);
+          focusSelectedCollectionItem(
+            getMenuCollection(root.menuId),
+            item.index
+          );
+          return;
+        }
       }
 
       root.navigation.container.onKeyDown?.(event);

--- a/src/components/menu/menu-item-parts.tsx
+++ b/src/components/menu/menu-item-parts.tsx
@@ -1,0 +1,39 @@
+import { Slot } from '@askrjs/askr/foundations/structures';
+import { mergeProps } from '@askrjs/askr/foundations/utilities';
+import type { MenuItemPartAsChildProps, MenuItemPartProps } from './menu.types';
+
+type PartProps = MenuItemPartProps | MenuItemPartAsChildProps;
+
+function MenuItemPart(props: PartProps, slot: string) {
+  const { asChild, children, ref, ...rest } = props;
+  const finalProps = mergeProps(rest, { ref, 'data-slot': slot });
+
+  if (asChild) {
+    return <Slot asChild {...finalProps} children={children} />;
+  }
+
+  return <span {...finalProps}>{children}</span>;
+}
+
+/** Optional leading visual for a Menu Item. */
+export function MenuItemIcon(props: MenuItemPartProps): JSX.Element;
+export function MenuItemIcon(props: MenuItemPartAsChildProps): JSX.Element;
+export function MenuItemIcon(props: PartProps) {
+  return MenuItemPart(props, 'menu-item-icon');
+}
+
+/** Primary visible label for a structured Menu Item. */
+export function MenuItemLabel(props: MenuItemPartProps): JSX.Element;
+export function MenuItemLabel(props: MenuItemPartAsChildProps): JSX.Element;
+export function MenuItemLabel(props: PartProps) {
+  return MenuItemPart(props, 'menu-item-label');
+}
+
+/** Optional supporting description for a structured Menu Item. */
+export function MenuItemDescription(props: MenuItemPartProps): JSX.Element;
+export function MenuItemDescription(
+  props: MenuItemPartAsChildProps
+): JSX.Element;
+export function MenuItemDescription(props: PartProps) {
+  return MenuItemPart(props, 'menu-item-description');
+}

--- a/src/components/menu/menu.types.ts
+++ b/src/components/menu/menu.types.ts
@@ -44,6 +44,11 @@ export type MenuItemProps = Omit<
 export type MenuItemAsChildProps = Omit<ButtonLikeAsChildProps, 'onPress'> &
   MenuItemOwnProps;
 
+/** Props for a presentational part within a Menu Item. */
+export type MenuItemPartProps = BoxProps<'span', HTMLSpanElement>;
+/** Props for a polymorphic presentational part within a Menu Item. */
+export type MenuItemPartAsChildProps = BoxAsChildProps;
+
 /** Props for Menu Group. */
 export type MenuGroupProps = BoxProps<'div', HTMLDivElement>;
 /** Props for the `asChild` (polymorphic) rendering of Menu Group. */

--- a/tests/browser/components/menu/behavior.test.tsx
+++ b/tests/browser/components/menu/behavior.test.tsx
@@ -5,6 +5,9 @@ import {
   Menu,
   MenuContent,
   MenuItem,
+  MenuItemDescription,
+  MenuItemIcon,
+  MenuItemLabel,
   MenuLabel,
   MenuSeparator,
 } from '../../../../src/components/menu';
@@ -33,6 +36,45 @@ describe('Menu - Behavior', () => {
 
     expect(items[0].getAttribute('tabindex')).toBe('0');
     expect(items[1].getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('should support standalone navigation links with structured item content', async () => {
+    container = mount(
+      <Menu>
+        <MenuContent aria-label="Workspaces">
+          <MenuItem asChild textValue="Alpha workspace">
+            <a href="#alpha">
+              <MenuItemIcon aria-hidden="true">A</MenuItemIcon>
+              <MenuItemLabel>Alpha</MenuItemLabel>
+              <MenuItemDescription>Production workspace</MenuItemDescription>
+            </a>
+          </MenuItem>
+          <MenuItem asChild textValue="Beta workspace">
+            <a href="#beta">
+              <MenuItemLabel>Beta</MenuItemLabel>
+              <MenuItemDescription>Staging workspace</MenuItemDescription>
+            </a>
+          </MenuItem>
+        </MenuContent>
+      </Menu>
+    );
+
+    const links = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('a')
+    );
+    links[0]!.focus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(links[1]);
+    await userEvent.keyboard('a');
+    expect(document.activeElement).toBe(links[0]);
+    await userEvent.keyboard('{End}');
+    expect(document.activeElement).toBe(links[1]);
+    await userEvent.keyboard('{Home}');
+    expect(document.activeElement).toBe(links[0]);
+    expect(
+      links[0]!.querySelector('[data-slot="menu-item-description"]')
+        ?.textContent
+    ).toBe('Production workspace');
   });
 
   it('should support nested menu item composition without direct child injection', () => {

--- a/tests/unit/types/public-api.type-test.ts
+++ b/tests/unit/types/public-api.type-test.ts
@@ -38,6 +38,9 @@ import {
   MenuContent,
   MenuGroup,
   MenuItem,
+  MenuItemDescription,
+  MenuItemIcon,
+  MenuItemLabel,
   MenuLabel,
   MenuSeparator,
   Popover,
@@ -110,6 +113,8 @@ import {
   type MenuContentAsChildProps,
   type MenuContentProps,
   type MenuItemAsChildProps,
+  type MenuItemPartAsChildProps,
+  type MenuItemPartProps,
   type MenuItemProps,
   type PopoverCloseAsChildProps,
   type PopoverCloseProps,
@@ -383,6 +388,11 @@ const menuItemAsChildProps: MenuItemAsChildProps = {
   children: slotChild,
   textValue: 'Menu item',
 };
+const menuItemPartProps: MenuItemPartProps = { children: 'Menu item' };
+const menuItemPartAsChildProps: MenuItemPartAsChildProps = {
+  asChild: true,
+  children: slotChild,
+};
 
 const dropdownContentProps: DropdownContentProps = {};
 const dropdownContentAsChildProps: DropdownContentAsChildProps = {
@@ -545,6 +555,9 @@ void [
   MenuContent,
   MenuGroup,
   MenuItem,
+  MenuItemDescription,
+  MenuItemIcon,
+  MenuItemLabel,
   MenuLabel,
   MenuSeparator,
   PopoverClose,
@@ -628,6 +641,8 @@ void [
   menuContentAsChildProps,
   menuItemProps,
   menuItemAsChildProps,
+  menuItemPartProps,
+  menuItemPartAsChildProps,
   dropdownTriggerVariant,
   dropdownTriggerSize,
   dropdownTriggerProps,


### PR DESCRIPTION
## Summary

- document Menu as the supported always-visible navigation-list primitive
- add structured item icon, label, and description parts
- verify link composition preserves roving focus and typeahead

Closes #78

## Validation

- npm run check
- npm audit --audit-level=high