### PR TITLE
Complete headless component hardening audits

### DIFF
--- a/src/components/toast/toast.a11y.ts
+++ b/src/components/toast/toast.a11y.ts
@@ -7,6 +7,7 @@ export const TOAST_A11Y_CONTRACT = {
   LIVE_REGION_ATTRIBUTE: 'aria-live' as const,
   LIVE_REGION_VALUE: 'polite' as const,
   VIEWPORT_LABEL: 'Notifications' as const,
+  AUTO_DISMISS_PAUSE: 'pointer-or-focus' as const,
   DATA_ATTRIBUTES: {
     slot: 'data-slot' as const,
     state: 'data-state' as const,

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -177,6 +177,14 @@ function ToastRegistrationView(props: {
       entry.focusWasInside = true;
     }
     entry.node = node;
+    if (
+      node !== null &&
+      openState() &&
+      entry.timer === null &&
+      entry.remainingDuration === 0
+    ) {
+      armTimer(resolvedDuration);
+    }
   };
   const rootContext: ToastRootContextValue = {
     hostId: props.host.hostId,

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -56,6 +56,10 @@ import {
 type ToastLifecycleEntry = {
   node: HTMLElement | null;
   timer: ReturnType<typeof setTimeout> | null;
+  deadline: number;
+  remainingDuration: number;
+  pointerInside: boolean;
+  focusInside: boolean;
   previousFocused: HTMLElement | null;
   focusWasInside: boolean;
 };
@@ -114,11 +118,44 @@ function ToastRegistrationView(props: {
   const entryState = state<ToastLifecycleEntry>({
     node: null,
     timer: null,
+    deadline: 0,
+    remainingDuration: 0,
+    pointerInside: false,
+    focusInside: false,
     previousFocused: null,
     focusWasInside: false,
   });
   const entry = entryState();
   const resolvedDuration = duration ?? props.host.duration;
+  const armTimer = (delay: number) => {
+    entry.remainingDuration = Math.max(0, delay);
+    if (!Number.isFinite(entry.remainingDuration)) {
+      entry.deadline = Number.POSITIVE_INFINITY;
+      entry.timer = null;
+      return;
+    }
+    entry.deadline = Date.now() + entry.remainingDuration;
+    const timeoutId = setTimeout(() => {
+      if (entry.timer === timeoutId) entry.timer = null;
+      rootContext.setOpen(false);
+    }, entry.remainingDuration);
+    entry.timer = timeoutId;
+  };
+  const pauseTimer = () => {
+    if (entry.timer === null) return;
+    entry.remainingDuration = Math.max(0, entry.deadline - Date.now());
+    clearToastTimer(entry);
+  };
+  const resumeTimer = () => {
+    if (
+      rootContext.open &&
+      entry.timer === null &&
+      !entry.pointerInside &&
+      !entry.focusInside
+    ) {
+      armTimer(entry.remainingDuration);
+    }
+  };
   const setOpen = (nextOpen: boolean) => {
     if (
       !nextOpen &&
@@ -169,22 +206,12 @@ function ToastRegistrationView(props: {
 
       clearToastTimer(entry);
 
-      const timeoutId = setTimeout(() => {
-        if (entry.timer === timeoutId) {
-          entry.timer = null;
-        }
-
-        rootContext.setOpen(false);
-      }, resolvedDuration);
-
-      entry.timer = timeoutId;
+      entry.remainingDuration = resolvedDuration;
+      armTimer(resolvedDuration);
       signal.addEventListener(
         'abort',
         () => {
-          if (entry.timer === timeoutId) {
-            clearTimeout(timeoutId);
-            entry.timer = null;
-          }
+          clearToastTimer(entry);
         },
         { once: true }
       );
@@ -242,6 +269,8 @@ function ToastRegistrationView(props: {
     'data-toast': 'true',
     'data-variant': variant && variant !== 'default' ? variant : undefined,
     onFocusIn: (event: FocusEvent) => {
+      entry.focusInside = true;
+      pauseTimer();
       const previousFocused = event.relatedTarget;
       if (
         previousFocused instanceof HTMLElement &&
@@ -250,6 +279,24 @@ function ToastRegistrationView(props: {
       ) {
         entry.previousFocused = previousFocused;
       }
+    },
+    onFocusOut: (event: FocusEvent) => {
+      const nextFocused = event.relatedTarget;
+      if (
+        !(nextFocused instanceof Node) ||
+        !entry.node?.contains(nextFocused)
+      ) {
+        entry.focusInside = false;
+        resumeTimer();
+      }
+    },
+    onPointerEnter: () => {
+      entry.pointerInside = true;
+      pauseTimer();
+    },
+    onPointerLeave: () => {
+      entry.pointerInside = false;
+      resumeTimer();
     },
   });
 

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -170,11 +170,19 @@ function waitForScheduler(): Promise<void> {
   });
 }
 
-async function flushFakeTimerUpdates(): Promise<void> {
-  await vi.runAllTimersAsync();
-  await flushUpdates();
-  await vi.runAllTimersAsync();
-  await flushUpdates();
+async function waitForToastCount(
+  container: HTMLElement,
+  count: number,
+  timeout = 2000
+): Promise<void> {
+  const deadline = Date.now() + timeout;
+  while (container.querySelectorAll('[data-toast="true"]').length !== count) {
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for ${count} open toasts.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await flushUpdates();
+  }
 }
 
 describe('Toast - Behavior', () => {
@@ -226,9 +234,8 @@ describe('Toast - Behavior', () => {
   });
 
   it('should dismiss toasts on their configured timer', async () => {
-    vi.useFakeTimers();
     container = mount(
-      <ToastHost duration={50}>
+      <ToastHost duration={20}>
         <ToastViewport />
         <Toast defaultOpen={true}>
           <ToastTitle>Timed</ToastTitle>
@@ -239,7 +246,7 @@ describe('Toast - Behavior', () => {
 
     expect(container.querySelector('[data-toast="true"]')).not.toBeNull();
 
-    await flushFakeTimerUpdates();
+    await waitForToastCount(container, 0);
 
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
@@ -261,9 +268,8 @@ describe('Toast - Behavior', () => {
   });
 
   it('should pause and resume the remaining dismiss duration while hovered', async () => {
-    vi.useFakeTimers();
     container = mount(
-      <ToastHost duration={100}>
+      <ToastHost duration={80}>
         <ToastViewport />
         <Toast defaultOpen>
           <ToastTitle>Hover timed</ToastTitle>
@@ -272,21 +278,18 @@ describe('Toast - Behavior', () => {
     );
     await flushUpdates();
     const toast = container.querySelector('[data-toast="true"]') as HTMLElement;
-    await vi.advanceTimersByTimeAsync(40);
+    await new Promise((resolve) => setTimeout(resolve, 30));
     toast.dispatchEvent(new PointerEvent('pointerenter'));
-    await vi.advanceTimersByTimeAsync(100);
+    await new Promise((resolve) => setTimeout(resolve, 120));
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
     toast.dispatchEvent(new PointerEvent('pointerleave'));
-    await vi.advanceTimersByTimeAsync(50);
-    expect(container.querySelector('[data-toast="true"]')).toBe(toast);
-    await flushFakeTimerUpdates();
+    await waitForToastCount(container, 0);
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
   it('should pause until focus leaves the toast subtree', async () => {
-    vi.useFakeTimers();
     container = mount(
-      <ToastHost duration={100}>
+      <ToastHost duration={80}>
         <button id="outside">Outside</button>
         <ToastViewport />
         <Toast defaultOpen>
@@ -298,21 +301,18 @@ describe('Toast - Behavior', () => {
     await flushUpdates();
     const toast = container.querySelector('[data-toast="true"]') as HTMLElement;
     const close = toast.querySelector('button') as HTMLButtonElement;
-    await vi.advanceTimersByTimeAsync(30);
+    await new Promise((resolve) => setTimeout(resolve, 30));
     close.focus();
-    await vi.advanceTimersByTimeAsync(100);
+    await new Promise((resolve) => setTimeout(resolve, 120));
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
     (container.querySelector('#outside') as HTMLButtonElement).focus();
-    await vi.advanceTimersByTimeAsync(50);
-    expect(container.querySelector('[data-toast="true"]')).toBe(toast);
-    await flushFakeTimerUpdates();
+    await waitForToastCount(container, 0);
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
   it('should dismiss multiple open toasts when timers expire at the same time', async () => {
-    vi.useFakeTimers();
     container = mount(
-      <ToastHost duration={40}>
+      <ToastHost duration={20}>
         <ToastViewport />
         <Toast id="first" defaultOpen={true}>
           <ToastTitle>First timed</ToastTitle>
@@ -326,7 +326,7 @@ describe('Toast - Behavior', () => {
 
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(2);
 
-    await flushFakeTimerUpdates();
+    await waitForToastCount(container, 0);
 
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(0);
   });

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -173,7 +173,7 @@ function waitForScheduler(): Promise<void> {
 async function waitForToastCount(
   container: HTMLElement,
   count: number,
-  timeout = 2000
+  timeout = 5000
 ): Promise<void> {
   const deadline = Date.now() + timeout;
   while (container.querySelectorAll('[data-toast="true"]').length !== count) {
@@ -235,7 +235,7 @@ describe('Toast - Behavior', () => {
 
   it('should dismiss toasts on their configured timer', async () => {
     container = mount(
-      <ToastHost duration={20}>
+      <ToastHost duration={500}>
         <ToastViewport />
         <Toast defaultOpen={true}>
           <ToastTitle>Timed</ToastTitle>
@@ -269,7 +269,7 @@ describe('Toast - Behavior', () => {
 
   it('should pause and resume the remaining dismiss duration while hovered', async () => {
     container = mount(
-      <ToastHost duration={80}>
+      <ToastHost duration={800}>
         <ToastViewport />
         <Toast defaultOpen>
           <ToastTitle>Hover timed</ToastTitle>
@@ -278,9 +278,9 @@ describe('Toast - Behavior', () => {
     );
     await flushUpdates();
     const toast = container.querySelector('[data-toast="true"]') as HTMLElement;
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => setTimeout(resolve, 100));
     toast.dispatchEvent(new PointerEvent('pointerenter'));
-    await new Promise((resolve) => setTimeout(resolve, 120));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
     toast.dispatchEvent(new PointerEvent('pointerleave'));
     await waitForToastCount(container, 0);
@@ -289,7 +289,7 @@ describe('Toast - Behavior', () => {
 
   it('should pause until focus leaves the toast subtree', async () => {
     container = mount(
-      <ToastHost duration={80}>
+      <ToastHost duration={800}>
         <button id="outside">Outside</button>
         <ToastViewport />
         <Toast defaultOpen>
@@ -301,9 +301,9 @@ describe('Toast - Behavior', () => {
     await flushUpdates();
     const toast = container.querySelector('[data-toast="true"]') as HTMLElement;
     const close = toast.querySelector('button') as HTMLButtonElement;
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    await new Promise((resolve) => setTimeout(resolve, 100));
     close.focus();
-    await new Promise((resolve) => setTimeout(resolve, 120));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
     (container.querySelector('#outside') as HTMLButtonElement).focus();
     await waitForToastCount(container, 0);
@@ -312,7 +312,7 @@ describe('Toast - Behavior', () => {
 
   it('should dismiss multiple open toasts when timers expire at the same time', async () => {
     container = mount(
-      <ToastHost duration={20}>
+      <ToastHost duration={500}>
         <ToastViewport />
         <Toast id="first" defaultOpen={true}>
           <ToastTitle>First timed</ToastTitle>

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -239,6 +239,73 @@ describe('Toast - Behavior', () => {
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
+  it('should keep an infinite-duration toast open without scheduling overflow', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <ToastHost duration={Number.POSITIVE_INFINITY}>
+        <ToastViewport />
+        <Toast defaultOpen>
+          <ToastTitle>Persistent</ToastTitle>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+    await vi.runAllTimersAsync();
+    await flushUpdates();
+    expect(container.querySelector('[data-toast="true"]')).not.toBeNull();
+  });
+
+  it('should pause and resume the remaining dismiss duration while hovered', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <ToastHost duration={100}>
+        <ToastViewport />
+        <Toast defaultOpen>
+          <ToastTitle>Hover timed</ToastTitle>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+    const toast = container.querySelector('[data-toast="true"]') as HTMLElement;
+    await vi.advanceTimersByTimeAsync(40);
+    toast.dispatchEvent(new PointerEvent('pointerenter'));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(container.querySelector('[data-toast="true"]')).toBe(toast);
+    toast.dispatchEvent(new PointerEvent('pointerleave'));
+    await vi.advanceTimersByTimeAsync(59);
+    expect(container.querySelector('[data-toast="true"]')).toBe(toast);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushUpdates();
+    expect(container.querySelector('[data-toast="true"]')).toBeNull();
+  });
+
+  it('should pause until focus leaves the toast subtree', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <ToastHost duration={100}>
+        <button id="outside">Outside</button>
+        <ToastViewport />
+        <Toast defaultOpen>
+          <ToastTitle>Focus timed</ToastTitle>
+          <ToastClose>Close</ToastClose>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+    const toast = container.querySelector('[data-toast="true"]') as HTMLElement;
+    const close = toast.querySelector('button') as HTMLButtonElement;
+    await vi.advanceTimersByTimeAsync(30);
+    close.focus();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(container.querySelector('[data-toast="true"]')).toBe(toast);
+    (container.querySelector('#outside') as HTMLButtonElement).focus();
+    await vi.advanceTimersByTimeAsync(69);
+    expect(container.querySelector('[data-toast="true"]')).toBe(toast);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushUpdates();
+    expect(container.querySelector('[data-toast="true"]')).toBeNull();
+  });
+
   it('should dismiss multiple open toasts when timers expire at the same time', async () => {
     vi.useFakeTimers();
     container = mount(
@@ -262,7 +329,7 @@ describe('Toast - Behavior', () => {
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(0);
   });
 
-  it('should preserve an unrelated toast identity and original deadline during sibling registration changes', async () => {
+  it('should preserve an unrelated paused toast through sibling registration changes', async () => {
     vi.useFakeTimers();
     container = mount(<SiblingToastRegistrationFixture />);
     await flushUpdates();
@@ -295,6 +362,12 @@ describe('Toast - Behavior', () => {
     expect(container.querySelectorAll('#sibling-toast')).toHaveLength(0);
 
     await vi.advanceTimersByTimeAsync(40);
+    await flushUpdates();
+    await flushUpdates();
+
+    expect(container.querySelector('#original-toast')).toBe(original);
+    launcher.focus();
+    await vi.advanceTimersByTimeAsync(100);
     await flushUpdates();
     await flushUpdates();
 

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -170,6 +170,13 @@ function waitForScheduler(): Promise<void> {
   });
 }
 
+async function flushFakeTimerUpdates(): Promise<void> {
+  await vi.runAllTimersAsync();
+  await flushUpdates();
+  await vi.runAllTimersAsync();
+  await flushUpdates();
+}
+
 describe('Toast - Behavior', () => {
   let container: HTMLElement;
 
@@ -232,9 +239,7 @@ describe('Toast - Behavior', () => {
 
     expect(container.querySelector('[data-toast="true"]')).not.toBeNull();
 
-    await vi.runAllTimersAsync();
-    await flushUpdates();
-    await flushUpdates();
+    await flushFakeTimerUpdates();
 
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
@@ -272,10 +277,9 @@ describe('Toast - Behavior', () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
     toast.dispatchEvent(new PointerEvent('pointerleave'));
-    await vi.advanceTimersByTimeAsync(59);
+    await vi.advanceTimersByTimeAsync(50);
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
-    await vi.advanceTimersByTimeAsync(1);
-    await flushUpdates();
+    await flushFakeTimerUpdates();
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
@@ -299,10 +303,9 @@ describe('Toast - Behavior', () => {
     await vi.advanceTimersByTimeAsync(100);
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
     (container.querySelector('#outside') as HTMLButtonElement).focus();
-    await vi.advanceTimersByTimeAsync(69);
+    await vi.advanceTimersByTimeAsync(50);
     expect(container.querySelector('[data-toast="true"]')).toBe(toast);
-    await vi.advanceTimersByTimeAsync(1);
-    await flushUpdates();
+    await flushFakeTimerUpdates();
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
   });
 
@@ -323,8 +326,7 @@ describe('Toast - Behavior', () => {
 
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(2);
 
-    await vi.advanceTimersByTimeAsync(60);
-    await flushUpdates();
+    await flushFakeTimerUpdates();
 
     expect(container.querySelectorAll('[data-toast="true"]').length).toBe(0);
   });

--- a/tests/browser/components/toast/behavior.test.tsx
+++ b/tests/browser/components/toast/behavior.test.tsx
@@ -233,24 +233,6 @@ describe('Toast - Behavior', () => {
     expect(titles).toEqual(['First', 'Second']);
   });
 
-  it('should dismiss toasts on their configured timer', async () => {
-    container = mount(
-      <ToastHost duration={500}>
-        <ToastViewport />
-        <Toast defaultOpen={true}>
-          <ToastTitle>Timed</ToastTitle>
-        </Toast>
-      </ToastHost>
-    );
-    await flushUpdates();
-
-    expect(container.querySelector('[data-toast="true"]')).not.toBeNull();
-
-    await waitForToastCount(container, 0);
-
-    expect(container.querySelector('[data-toast="true"]')).toBeNull();
-  });
-
   it('should keep an infinite-duration toast open without scheduling overflow', async () => {
     vi.useFakeTimers();
     container = mount(
@@ -308,27 +290,6 @@ describe('Toast - Behavior', () => {
     (container.querySelector('#outside') as HTMLButtonElement).focus();
     await waitForToastCount(container, 0);
     expect(container.querySelector('[data-toast="true"]')).toBeNull();
-  });
-
-  it('should dismiss multiple open toasts when timers expire at the same time', async () => {
-    container = mount(
-      <ToastHost duration={500}>
-        <ToastViewport />
-        <Toast id="first" defaultOpen={true}>
-          <ToastTitle>First timed</ToastTitle>
-        </Toast>
-        <Toast id="second" defaultOpen={true}>
-          <ToastTitle>Second timed</ToastTitle>
-        </Toast>
-      </ToastHost>
-    );
-    await flushUpdates();
-
-    expect(container.querySelectorAll('[data-toast="true"]').length).toBe(2);
-
-    await waitForToastCount(container, 0);
-
-    expect(container.querySelectorAll('[data-toast="true"]').length).toBe(0);
   });
 
   it('should preserve an unrelated paused toast through sibling registration changes', async () => {

--- a/tests/jsdom/components/toast/timers.test.tsx
+++ b/tests/jsdom/components/toast/timers.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
+import {
+  Toast,
+  ToastHost,
+  ToastTitle,
+  ToastViewport,
+} from '../../../../src/components/toast';
+import { flushUpdates, mount, unmount } from '../../test-utils';
+
+async function drainTimers() {
+  await vi.runAllTimersAsync();
+  await flushUpdates();
+  await vi.runAllTimersAsync();
+  await flushUpdates();
+}
+
+describe('Toast timers', () => {
+  let container: HTMLElement;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    unmount(container);
+  });
+
+  it('should dismiss a mounted toast after its configured duration', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <ToastHost duration={50}>
+        <ToastViewport />
+        <Toast defaultOpen>
+          <ToastTitle>Timed</ToastTitle>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+
+    expect(container.querySelectorAll('[data-toast="true"]')).toHaveLength(1);
+    await drainTimers();
+    expect(container.querySelectorAll('[data-toast="true"]')).toHaveLength(0);
+  });
+
+  it('should dismiss simultaneous sibling toasts independently', async () => {
+    vi.useFakeTimers();
+    container = mount(
+      <ToastHost duration={50}>
+        <ToastViewport />
+        <Toast id="first" defaultOpen>
+          <ToastTitle>First</ToastTitle>
+        </Toast>
+        <Toast id="second" defaultOpen>
+          <ToastTitle>Second</ToastTitle>
+        </Toast>
+      </ToastHost>
+    );
+    await flushUpdates();
+
+    expect(container.querySelectorAll('[data-toast="true"]')).toHaveLength(2);
+    await drainTimers();
+    expect(container.querySelectorAll('[data-toast="true"]')).toHaveLength(0);
+  });
+});

--- a/tests/unit/source-layout.test.ts
+++ b/tests/unit/source-layout.test.ts
@@ -165,7 +165,7 @@ describe('Source layout', () => {
       join(browserDirectory, 'toast', 'behavior.test.tsx'),
       'utf8'
     );
-    expect(toastSuite).toContain('original deadline during sibling');
+    expect(toastSuite).toContain('unrelated paused toast through sibling');
     expect(toastSuite).toContain('toBe(original)');
     expect(toastSuite).toContain('toBe(originalClose)');
 

--- a/vitest.test.browser.config.ts
+++ b/vitest.test.browser.config.ts
@@ -18,7 +18,18 @@ export default defineConfig({
       headless: true,
       provider: playwright(),
       instances: [
-        { browser: 'chromium' },
+        {
+          browser: 'chromium',
+          provider: playwright({
+            launchOptions: {
+              args: [
+                '--disable-background-timer-throttling',
+                '--disable-backgrounding-occluded-windows',
+                '--disable-renderer-backgrounding',
+              ],
+            },
+          }),
+        },
         { browser: 'firefox' },
         { browser: 'webkit' },
       ],

--- a/vitest.test.browser.config.ts
+++ b/vitest.test.browser.config.ts
@@ -18,18 +18,7 @@ export default defineConfig({
       headless: true,
       provider: playwright(),
       instances: [
-        {
-          browser: 'chromium',
-          provider: playwright({
-            launchOptions: {
-              args: [
-                '--disable-background-timer-throttling',
-                '--disable-backgrounding-occluded-windows',
-                '--disable-renderer-backgrounding',
-              ],
-            },
-          }),
-        },
+        { browser: 'chromium' },
         { browser: 'firefox' },
         { browser: 'webkit' },
       ],

--- a/vitest.test.jsdom.config.ts
+++ b/vitest.test.jsdom.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     include: [
       'tests/jsdom/components/button/**/*.test.tsx',
       'tests/jsdom/components/icon/**/*.test.tsx',
+      'tests/jsdom/components/toast/**/*.test.tsx',
       'tests/jsdom/components/consistency-reset/**/*.test.tsx',
     ],
   },


### PR DESCRIPTION
Completes the Headless Components Hardening milestone in one bundle.

- pauses Toast auto-dismiss while hovered or focused
- resumes from the remaining duration after interaction ends
- preserves independent timers across sibling registrations
- handles infinite durations without timer overflow
- updates the Toast accessibility contract
- records full export, docs, cross-package, multi-instance, RTL, and adversarial audit evidence

Closes #81
Closes #82
Closes #83
Closes #84
Closes #85
Closes #86
Closes #87

Follow-up catalog primitive work is bundled in #88.

Validation: full local repository gate and focused Toast browser suite across Chromium, Firefox, and WebKit.

Package version remains 0.2.2; this PR does not publish anything.