### PR TITLE
docs: define themes behavior boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,18 @@ The package exports components directly from the root and per-component subpaths
 Prefer the per-component subpaths when you want a smaller surface area.
 
 For the full surface and composition examples, start with the docs above.
+
+## Themes catalog boundary
+
+`@askrjs/themes` also publishes styling-only compatibility anatomy for Tabs,
+Combobox, Calendar/DatePicker, Command, NavigationMenu, Carousel,
+ResizablePanelGroup, and InputOTP. Those names are not `@askrjs/ui`
+primitives and do not provide widget state, keyboard interaction, focus
+management, or ARIA relationships. Applications must not treat those themed
+slots as behavioral widgets.
+
+When Askr adds behavior for one of these families, the implementation belongs
+in this package first and must meet the same controlled/uncontrolled state,
+keyboard, focus, disabled, RTL, forced-colors, misuse, determinism, and browser
+coverage requirements as every existing public family. Themes may then compose
+that public primitive rather than reproducing its state.

--- a/tests/unit/docs-contract.test.ts
+++ b/tests/unit/docs-contract.test.ts
@@ -183,4 +183,26 @@ describe('Docs contract', () => {
       ).toBe(true);
     }
   });
+
+  it('should document styling-only themes catalog families as outside the behavioral surface', () => {
+    const readme = readFileSync(join(process.cwd(), 'README.md'), 'utf8');
+
+    for (const family of [
+      'Tabs',
+      'Combobox',
+      'Calendar/DatePicker',
+      'Command',
+      'NavigationMenu',
+      'Carousel',
+      'ResizablePanelGroup',
+      'InputOTP',
+    ]) {
+      expect(readme, family).toContain(family);
+    }
+
+    expect(readme).toContain('styling-only compatibility anatomy');
+    expect(readme).toContain('do not provide widget state');
+    expect(readme).toContain('Themes may then compose');
+    expect(readme).toContain('rather than reproducing its state');
+  });
 });


### PR DESCRIPTION
## Summary

- document every styling-only themes catalog family that is outside the UI behavioral surface
- define the requirements a future UI primitive must satisfy before themes can compose it
- lock the boundary with a unit contract

Part of #88.

## Validation

- `npm run check`
- package version remains `0.2.2`; no package or publish metadata changed