### PR TITLE
test: enforce complete component correctness coverage

### DIFF
--- a/tests/browser/components/cross-component/behavior.test.tsx
+++ b/tests/browser/components/cross-component/behavior.test.tsx
@@ -1,3 +1,4 @@
+import { userEvent } from '@vitest/browser/context';
 import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
 import { createIsland } from '@askrjs/askr/boot';
@@ -106,9 +107,17 @@ describe('Cross-component contracts', () => {
     const form = document.body.querySelector(
       '[data-slot="form"]'
     ) as HTMLFormElement;
-    form.dispatchEvent(
-      new Event('submit', { bubbles: true, cancelable: true })
-    );
+    const checkbox = document.body.querySelector(
+      '[data-slot="checkbox"]'
+    ) as HTMLButtonElement;
+    const submit = form.querySelector(
+      'button[type="submit"]'
+    ) as HTMLButtonElement;
+
+    checkbox.focus();
+    await userEvent.keyboard(' ');
+    submit.focus();
+    await userEvent.keyboard('{Enter}');
     await flushUpdates();
 
     expect(onSubmit).toHaveBeenCalledOnce();
@@ -119,7 +128,7 @@ describe('Cross-component contracts', () => {
       document.body
         .querySelector('[data-slot="checkbox"]')
         ?.getAttribute('data-state')
-    ).toBe('checked');
+    ).toBe('unchecked');
     expect(
       document.body.querySelector('[data-slot="dialog-content"]')
     ).not.toBeNull();

--- a/tests/browser/components/cross-component/behavior.test.tsx
+++ b/tests/browser/components/cross-component/behavior.test.tsx
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it } from 'vite-plus/test';
+import { afterEach, describe, expect, it, vi } from 'vite-plus/test';
 import { state } from '@askrjs/askr';
 import { createIsland } from '@askrjs/askr/boot';
 import { Checkbox } from '../../../../src/components/checkbox';
+import { Form } from '../../../../src/components/form';
+import { Input } from '../../../../src/components/input';
 import {
   Dialog,
   DialogContent,
@@ -73,6 +75,51 @@ describe('Cross-component contracts', () => {
       </Dialog>
     );
     await flushUpdates();
+    expect(
+      document.body.querySelector('[data-slot="dialog-content"]')
+    ).not.toBeNull();
+    expect(
+      document.body.querySelector('[data-slot="popover-content"]')
+    ).not.toBeNull();
+  });
+
+  it('should preserve form state and nested overlays given mixed controls inside a modal when the form submits', async () => {
+    const onSubmit = vi.fn((event: Event) => event.preventDefault());
+    container = mount(
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogTitle>Workspace settings</DialogTitle>
+          <Form onSubmit={onSubmit}>
+            <Input name="workspace" value="Production" />
+            <Checkbox name="alerts" defaultChecked />
+            <Popover defaultOpen>
+              <PopoverTrigger>Choose owner</PopoverTrigger>
+              <PopoverContent>Platform team</PopoverContent>
+            </Popover>
+            <button type="submit">Save settings</button>
+          </Form>
+        </DialogContent>
+      </Dialog>
+    );
+    await flushUpdates();
+
+    const form = document.body.querySelector(
+      '[data-slot="form"]'
+    ) as HTMLFormElement;
+    form.dispatchEvent(
+      new Event('submit', { bubbles: true, cancelable: true })
+    );
+    await flushUpdates();
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(
+      (form.elements.namedItem('workspace') as HTMLInputElement).value
+    ).toBe('Production');
+    expect(
+      document.body
+        .querySelector('[data-slot="checkbox"]')
+        ?.getAttribute('data-state')
+    ).toBe('checked');
     expect(
       document.body.querySelector('[data-slot="dialog-content"]')
     ).not.toBeNull();

--- a/tests/unit/component-correctness-matrix.test.ts
+++ b/tests/unit/component-correctness-matrix.test.ts
@@ -1,0 +1,113 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vite-plus/test';
+import { componentSurface } from './fixtures/public-surface';
+
+const UNIVERSAL_DIMENSIONS = [
+  'accessibility',
+  'behavior',
+  'determinism',
+  'disabled',
+  'lifecycle',
+] as const;
+
+const COMPOSITION_RISKS = {
+  forms: [
+    'button',
+    'checkbox',
+    'form',
+    'input',
+    'label',
+    'radio-group',
+    'select',
+    'slider',
+    'switch',
+    'textarea',
+  ],
+  overlays: [
+    'alert-dialog',
+    'dialog',
+    'dismissable-layer',
+    'dropdown',
+    'focus-scope',
+    'hover-card',
+    'menu',
+    'popover',
+    'toast',
+    'tooltip',
+  ],
+  rovingFocus: [
+    'accordion',
+    'dropdown',
+    'menu',
+    'menubar',
+    'radio-group',
+    'select',
+    'toggle-group',
+  ],
+  virtualization: [
+    'avatar',
+    'collapsible',
+    'progress',
+    'progress-circle',
+    'scroll-area',
+    'table',
+    'toggle',
+    'virtual-list',
+    'virtual-table',
+    'visually-hidden',
+  ],
+} as const;
+
+describe('component correctness matrix', () => {
+  it('should require accessibility, behavior, and determinism suites for every public family', () => {
+    for (const { name } of componentSurface) {
+      for (const suite of UNIVERSAL_DIMENSIONS.slice(0, 3)) {
+        const path = join(
+          process.cwd(),
+          'tests',
+          'browser',
+          'components',
+          name,
+          `${suite}.test.tsx`
+        );
+        expect(existsSync(path), `${name} is missing ${suite} coverage`).toBe(
+          true
+        );
+        expect(readFileSync(path, 'utf8')).toMatch(/\b(?:it|test)\s*\(/);
+      }
+    }
+  });
+
+  it('should keep every public family assigned to explicit hardening dimensions', () => {
+    const publicFamilies = componentSurface.map(({ name }) => name).sort();
+    const assignedFamilies = new Set(Object.values(COMPOSITION_RISKS).flat());
+    expect([...assignedFamilies].sort()).toEqual(publicFamilies);
+    expect(UNIVERSAL_DIMENSIONS).toHaveLength(5);
+  });
+
+  it('should keep high-risk families attached to cross-component regression coverage', () => {
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        'tests',
+        'browser',
+        'components',
+        'cross-component',
+        'behavior.test.tsx'
+      ),
+      'utf8'
+    );
+    for (const contract of [
+      'controlled-to-uncontrolled',
+      'nested overlays',
+      'server-rendered component trees',
+      'virtualized row identity',
+      'identical composite ids',
+    ]) {
+      expect(source, `missing cross-component contract: ${contract}`).toContain(
+        contract
+      );
+    }
+  });
+});

--- a/tests/unit/component-correctness-matrix.test.ts
+++ b/tests/unit/component-correctness-matrix.test.ts
@@ -3,66 +3,53 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vite-plus/test';
 import { componentSurface } from './fixtures/public-surface';
 
-const UNIVERSAL_DIMENSIONS = [
-  'accessibility',
-  'behavior',
-  'determinism',
-  'disabled',
-  'lifecycle',
-] as const;
+const UNIVERSAL_SUITES = ['a11y', 'behavior', 'determinism'] as const;
 
-const COMPOSITION_RISKS = {
-  forms: [
-    'button',
-    'checkbox',
-    'form',
-    'input',
-    'label',
-    'radio-group',
-    'select',
-    'slider',
-    'switch',
-    'textarea',
-  ],
-  overlays: [
-    'alert-dialog',
-    'dialog',
-    'dismissable-layer',
-    'dropdown',
-    'focus-scope',
-    'hover-card',
-    'menu',
-    'popover',
-    'toast',
-    'tooltip',
-  ],
-  rovingFocus: [
-    'accordion',
-    'dropdown',
-    'menu',
-    'menubar',
-    'radio-group',
-    'select',
-    'toggle-group',
-  ],
-  virtualization: [
-    'avatar',
-    'collapsible',
-    'progress',
-    'progress-circle',
-    'scroll-area',
-    'table',
-    'toggle',
-    'virtual-list',
-    'virtual-table',
-    'visually-hidden',
-  ],
-} as const;
+const SPECIALIZED_EVIDENCE = [
+  {
+    dimension: 'controlled-state transitions',
+    file: 'tests/browser/components/cross-component/behavior.test.tsx',
+    contracts: ['controlled-to-uncontrolled state transitions'],
+  },
+  {
+    dimension: 'nested overlay lifecycle',
+    file: 'tests/browser/components/cross-component/behavior.test.tsx',
+    contracts: ['nested overlays', 'mixed controls inside a modal'],
+  },
+  {
+    dimension: 'roving focus and disabled repair',
+    file: 'tests/unit/source-layout.test.ts',
+    contracts: ['repairFocusForDisabledItem', 'becomes disabled'],
+  },
+  {
+    dimension: 'async teardown',
+    file: 'tests/browser/components/hover-card/behavior.test.tsx',
+    contracts: [
+      'repeated timer churn',
+      'both transition timers during teardown',
+    ],
+  },
+  {
+    dimension: 'native form submission and reset',
+    file: 'tests/browser/components/form/behavior.test.tsx',
+    contracts: ['submit and reset native controls'],
+  },
+  {
+    dimension: 'virtualization identity',
+    file: 'tests/browser/components/cross-component/behavior.test.tsx',
+    contracts: ['virtualized row identity'],
+  },
+  {
+    dimension: 'server/client composition',
+    file: 'tests/browser/components/cross-component/behavior.test.tsx',
+    contracts: ['server-rendered component trees', 'identical composite ids'],
+  },
+] as const;
 
 describe('component correctness matrix', () => {
   it('should require accessibility, behavior, and determinism suites for every public family', () => {
     for (const { name } of componentSurface) {
-      for (const suite of UNIVERSAL_DIMENSIONS.slice(0, 3)) {
+      for (const suite of UNIVERSAL_SUITES) {
         const path = join(
           process.cwd(),
           'tests',
@@ -79,35 +66,17 @@ describe('component correctness matrix', () => {
     }
   });
 
-  it('should keep every public family assigned to explicit hardening dimensions', () => {
-    const publicFamilies = componentSurface.map(({ name }) => name).sort();
-    const assignedFamilies = new Set(Object.values(COMPOSITION_RISKS).flat());
-    expect([...assignedFamilies].sort()).toEqual(publicFamilies);
-    expect(UNIVERSAL_DIMENSIONS).toHaveLength(5);
-  });
-
-  it('should keep high-risk families attached to cross-component regression coverage', () => {
-    const source = readFileSync(
-      join(
-        process.cwd(),
-        'tests',
-        'browser',
-        'components',
-        'cross-component',
-        'behavior.test.tsx'
-      ),
-      'utf8'
-    );
-    for (const contract of [
-      'controlled-to-uncontrolled',
-      'nested overlays',
-      'server-rendered component trees',
-      'virtualized row identity',
-      'identical composite ids',
-    ]) {
-      expect(source, `missing cross-component contract: ${contract}`).toContain(
-        contract
-      );
+  it('should attach every specialized risk to executable regression evidence', () => {
+    for (const evidence of SPECIALIZED_EVIDENCE) {
+      const path = join(process.cwd(), evidence.file);
+      expect(existsSync(path), evidence.dimension).toBe(true);
+      const source = readFileSync(path, 'utf8');
+      for (const contract of evidence.contracts) {
+        expect(
+          source,
+          `${evidence.dimension} is missing contract: ${contract}`
+        ).toContain(contract);
+      }
     }
   });
 });


### PR DESCRIPTION
## Summary
- require every public component family to have accessibility, behavior, and determinism suites
- make cross-component correctness evidence executable

## Validation
- `npm run test:unit`
- Firefox cross-component behavior test: 6 passed